### PR TITLE
Quite a lot of changes. Especially to ContextMenu.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     modImplementation "dev.isxander:yet-another-config-lib:${project.yacl_version}"
 
-    modApi "com.terraformersmc:modmenu:11.0.1"
+    modApi "com.terraformersmc:modmenu:${project.modmenu_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,16 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
-yarn_mappings=1.21+build.2
-loader_version=0.15.11
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
+loader_version=0.16.2
 
 # Mod Properties
-mod_version = 2.1.0
+mod_version = 2.2.0
 maven_group = com.tanishisherewith
 archives_base_name = dynamichud
 
 # Dependencies
-fabric_version=0.100.3+1.21
+fabric_version=0.102.1+1.21.1
 yacl_version=3.5.0+1.21-fabric
+modmenu_version = 11.0.2

--- a/src/main/java/com/tanishisherewith/dynamichud/DynamicHUD.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/DynamicHUD.java
@@ -6,6 +6,7 @@ import com.tanishisherewith.dynamichud.utils.BooleanPool;
 import com.tanishisherewith.dynamichud.widget.Widget;
 import com.tanishisherewith.dynamichud.widget.WidgetManager;
 import com.tanishisherewith.dynamichud.widget.WidgetRenderer;
+import com.tanishisherewith.dynamichud.widgets.ItemWidget;
 import com.tanishisherewith.dynamichud.widgets.TextWidget;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
@@ -73,7 +74,8 @@ public class DynamicHUD implements ClientModInitializer {
 
         // Add WidgetData of included widgets
         WidgetManager.registerCustomWidgets(
-                TextWidget.DATA
+                TextWidget.DATA,
+                ItemWidget.DATA
         );
 
         //YACL load
@@ -112,7 +114,7 @@ public class DynamicHUD implements ClientModInitializer {
                         DHIntegration.initAfter();
 
                         // Get the instance of AbstractMoveableScreen
-                        screen = Objects.requireNonNull( DHIntegration.getMovableScreen());
+                        screen = Objects.requireNonNull(DHIntegration.getMovableScreen());
 
                         // Get the keybind to open the screen instance
                         binding = DHIntegration.getKeyBind();
@@ -155,11 +157,11 @@ public class DynamicHUD implements ClientModInitializer {
                         if (e instanceof IOException) {
                             logger.warn("An error has occurred while loading widgets of mod {}", modId, e);
                         } else {
-                            logger.warn("Mod {} has improper implementation of DynamicHUD", modId, e);
+                            logger.error("Mod {} has improper implementation of DynamicHUD", modId, e);
                         }
                     }
                 });
-        printInfo("(DynamicHUD) Integration of mods found was successful");
+        printInfo("(DynamicHUD) Integration of supported mods was successful");
 
 
         //Global config saving (YACL)

--- a/src/main/java/com/tanishisherewith/dynamichud/DynamicHUD.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/DynamicHUD.java
@@ -163,16 +163,6 @@ public class DynamicHUD implements ClientModInitializer {
                 });
         printInfo("(DynamicHUD) Integration of supported mods was successful");
 
-
-        //Global config saving (YACL)
-        ServerLifecycleEvents.SERVER_STOPPING.register(server -> GlobalConfig.HANDLER.save());
-        ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, resourceManager, s) -> GlobalConfig.HANDLER.save());
-        ServerPlayConnectionEvents.DISCONNECT.register((handler, packetSender) -> GlobalConfig.HANDLER.save());
-        ClientLifecycleEvents.CLIENT_STOPPING.register((minecraftClient) -> {
-            GlobalConfig.HANDLER.save();
-        });
-
-
         //In game screen render.
         HudRenderCallback.EVENT.register(new HudRender());
     }

--- a/src/main/java/com/tanishisherewith/dynamichud/DynamicHUD.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/DynamicHUD.java
@@ -104,7 +104,7 @@ public class DynamicHUD implements ClientModInitializer {
                         widgetsFile = DHIntegration.getWidgetsFile();
 
                         // Adds / loads widgets from file
-                        if (widgetsFile.exists()) {
+                        if (WidgetManager.doesWidgetFileExist(widgetsFile)) {
                             WidgetManager.loadWidgets(widgetsFile);
                         } else {
                             DHIntegration.addWidgets();

--- a/src/main/java/com/tanishisherewith/dynamichud/DynamicHudIntegration.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/DynamicHudIntegration.java
@@ -9,7 +9,6 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import org.lwjgl.glfw.GLFW;
-import org.lwjgl.system.NonnullDefault;
 
 import java.io.File;
 
@@ -85,7 +84,7 @@ public interface DynamicHudIntegration {
      *     WidgetManager.registerCustomWidget(TextWidget.DATA);
      *     }
      * </pre>
-     *
+     * <p>
      * Custom widgets can be registered in any method in the interface
      * but to avoid any errors and mishaps it is recommended you add them here
      */
@@ -125,11 +124,11 @@ public interface DynamicHudIntegration {
      * <h3>
      * !! Should never be null !!
      * </h3>
-     *</p>
+     * </p>
      *
      * @return The movable screen.
      */
-   AbstractMoveableScreen getMovableScreen();
+    AbstractMoveableScreen getMovableScreen();
 
     /**
      * To return a {@link WidgetRenderer} object.

--- a/src/main/java/com/tanishisherewith/dynamichud/DynamicHudTest.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/DynamicHudTest.java
@@ -51,8 +51,8 @@ public class DynamicHudTest implements DynamicHudIntegration {
                 .build();
 
         DynamicHUDWidget = new TextWidget.Builder()
-                .setX(5)
-                .setY(5)
+                .setX(0)
+                .setY(0)
                 .setDraggable(false)
                 .rainbow(true)
                 .setDRKey("DynamicHUD")

--- a/src/main/java/com/tanishisherewith/dynamichud/HudRender.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/HudRender.java
@@ -9,7 +9,7 @@ import net.minecraft.client.render.RenderTickCounter;
  * Using the fabric event {@link HudRenderCallback} to render widgets in the game HUD.
  * Mouse positions are passed in the negatives even though theoretically it's in the centre of the screen.
  */
-public class HudRender implements HudRenderCallback{
+public class HudRender implements HudRenderCallback {
 
     @Override
     public void onHudRender(DrawContext drawContext, RenderTickCounter tickCounter) {

--- a/src/main/java/com/tanishisherewith/dynamichud/ModMenuIntegration.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/ModMenuIntegration.java
@@ -7,10 +7,8 @@ import net.minecraft.client.gui.screen.Screen;
 
 
 public class ModMenuIntegration implements ModMenuApi {
-    public static Screen YACL_CONFIG_SCREEN = GlobalConfig.get().createYACLGUI();
-
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return parent -> YACL_CONFIG_SCREEN;
+        return parent -> GlobalConfig.get().createYACLGUI();
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/ModMenuIntegration.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/ModMenuIntegration.java
@@ -3,7 +3,6 @@ package com.tanishisherewith.dynamichud;
 import com.tanishisherewith.dynamichud.config.GlobalConfig;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
-import net.minecraft.client.gui.screen.Screen;
 
 
 public class ModMenuIntegration implements ModMenuApi {

--- a/src/main/java/com/tanishisherewith/dynamichud/config/GlobalConfig.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/config/GlobalConfig.java
@@ -3,6 +3,7 @@ package com.tanishisherewith.dynamichud.config;
 import dev.isxander.yacl3.api.*;
 import dev.isxander.yacl3.api.controller.BooleanControllerBuilder;
 import dev.isxander.yacl3.api.controller.FloatSliderControllerBuilder;
+import dev.isxander.yacl3.api.controller.IntegerFieldControllerBuilder;
 import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
@@ -19,6 +20,7 @@ public final class GlobalConfig {
                     .setJson5(true)
                     .build())
             .build();
+
     private static final GlobalConfig INSTANCE = new GlobalConfig();
     /**
      * Common scale for all widgets. Set by the user using YACL.
@@ -31,6 +33,9 @@ public final class GlobalConfig {
 
     @SerialEntry
     private boolean showColorPickerPreview = true;
+
+    @SerialEntry
+    private int snapSize = 100;
 
     public static GlobalConfig get() {
         return INSTANCE;
@@ -63,8 +68,15 @@ public final class GlobalConfig {
                                         .binding(true, () -> this.displayDescriptions, newVal -> this.displayDescriptions = newVal)
                                         .controller(booleanOption -> BooleanControllerBuilder.create(booleanOption).yesNoFormatter())
                                         .build())
+                                .option(Option.<Integer>createBuilder()
+                                        .name(Text.literal("Snap Size"))
+                                        .description(OptionDescription.of(Text.literal("Grid size for snapping widgets")))
+                                        .binding( 100, () -> this.snapSize, newVal -> this.snapSize = newVal)
+                                        .controller(integerOption -> IntegerFieldControllerBuilder.create(integerOption).range(10,500))
+                                        .build())
                                 .build())
                         .build())
+                .save(HANDLER::save)
                 .build()
                 .generateScreen(null);
     }
@@ -78,5 +90,9 @@ public final class GlobalConfig {
 
     public boolean shouldDisplayDescriptions() {
         return displayDescriptions;
+    }
+
+    public int getSnapSize() {
+        return snapSize;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/config/GlobalConfig.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/config/GlobalConfig.java
@@ -41,7 +41,7 @@ public final class GlobalConfig {
         return INSTANCE;
     }
 
-    public final Screen createYACLGUI() {
+    public Screen createYACLGUI() {
         return YetAnotherConfigLib.createBuilder()
                 .title(Text.literal("DynamicHUD config screen."))
                 .category(ConfigCategory.createBuilder()
@@ -71,8 +71,8 @@ public final class GlobalConfig {
                                 .option(Option.<Integer>createBuilder()
                                         .name(Text.literal("Snap Size"))
                                         .description(OptionDescription.of(Text.literal("Grid size for snapping widgets")))
-                                        .binding( 100, () -> this.snapSize, newVal -> this.snapSize = newVal)
-                                        .controller(integerOption -> IntegerFieldControllerBuilder.create(integerOption).range(10,500))
+                                        .binding(100, () -> this.snapSize, newVal -> this.snapSize = newVal)
+                                        .controller(integerOption -> IntegerFieldControllerBuilder.create(integerOption).range(10, 500))
                                         .build())
                                 .build())
                         .build())
@@ -80,7 +80,8 @@ public final class GlobalConfig {
                 .build()
                 .generateScreen(null);
     }
-    public float getScale(){
+
+    public float getScale() {
         return scale;
     }
 

--- a/src/main/java/com/tanishisherewith/dynamichud/helpers/DrawHelper.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/helpers/DrawHelper.java
@@ -47,7 +47,7 @@ public class DrawHelper {
         RenderSystem.defaultBlendFunc();
         RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
         RenderSystem.setShader(GameRenderer::getPositionColorProgram);
-        
+
         switch (direction) {
             case LEFT_RIGHT:
                 bufferBuilder.vertex(matrix4f, x, y + height, 0.0F).color(startRed, startGreen, startBlue, startAlpha);
@@ -508,7 +508,7 @@ public class DrawHelper {
         float alpha = (float) (color >> 24 & 255) / 255.0F;
 
         Tessellator tessellator = Tessellator.getInstance();
-        BufferBuilder bufferBuilder =  tessellator.begin(VertexFormat.DrawMode.TRIANGLE_FAN, VertexFormats.POSITION_COLOR);
+        BufferBuilder bufferBuilder = tessellator.begin(VertexFormat.DrawMode.TRIANGLE_FAN, VertexFormats.POSITION_COLOR);
 
         RenderSystem.setShader(GameRenderer::getPositionColorProgram);
         RenderSystem.enableBlend();

--- a/src/main/java/com/tanishisherewith/dynamichud/helpers/TextureHelper.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/helpers/TextureHelper.java
@@ -14,7 +14,7 @@ public class TextureHelper {
     static MinecraftClient mc = MinecraftClient.getInstance();
 
     public static NativeImage loadTexture(Identifier textureId) {
-        if(mc.getResourceManager().getResource(textureId).isPresent()) {
+        if (mc.getResourceManager().getResource(textureId).isPresent()) {
             try (InputStream inputStream = mc.getResourceManager().getResource(textureId).get().getInputStream()) {
                 return NativeImage.read(inputStream);
             } catch (IOException e) {
@@ -24,7 +24,7 @@ public class TextureHelper {
         return null;
     }
 
-    public  static NativeImage resizeTexture(NativeImage image, int newWidth, int newHeight) {
+    public static NativeImage resizeTexture(NativeImage image, int newWidth, int newHeight) {
         NativeImage result = new NativeImage(newWidth, newHeight, false);
 
         int oldWidth = image.getWidth();
@@ -41,49 +41,51 @@ public class TextureHelper {
 
         return result;
     }
+
     public static NativeImage resizeTextureUsingBilinearInterpolation(NativeImage image, int newWidth, int newHeight) {
         NativeImage result = new NativeImage(newWidth, newHeight, false);
 
-        float x_ratio = ((float)(image.getWidth()-1))/newWidth;
-        float y_ratio = ((float)(image.getHeight()-1))/newHeight;
+        float x_ratio = ((float) (image.getWidth() - 1)) / newWidth;
+        float y_ratio = ((float) (image.getHeight() - 1)) / newHeight;
         float x_diff, y_diff, blue, red, green;
         int offset, a, b, c, d, index;
 
-        for (int i=0;i<newHeight;i++) {
-            for (int j=0;j<newWidth;j++) {
-                int x = (int)(x_ratio * j);
-                int y = (int)(y_ratio * i);
+        for (int i = 0; i < newHeight; i++) {
+            for (int j = 0; j < newWidth; j++) {
+                int x = (int) (x_ratio * j);
+                int y = (int) (y_ratio * i);
                 x_diff = (x_ratio * j) - x;
                 y_diff = (y_ratio * i) - y;
 
                 // Indexes of the 4 surrounding pixels
                 a = image.getColor(x, y);
-                b = image.getColor(x+1, y);
-                c = image.getColor(x, y+1);
-                d = image.getColor(x+1, y+1);
+                b = image.getColor(x + 1, y);
+                c = image.getColor(x, y + 1);
+                d = image.getColor(x + 1, y + 1);
 
                 // Blue element
-                blue = (a&0xff)*(1-x_diff)*(1-y_diff) + (b&0xff)*(x_diff)*(1-y_diff) +
-                        (c&0xff)*(y_diff)*(1-x_diff)   + (d&0xff)*(x_diff*y_diff);
+                blue = (a & 0xff) * (1 - x_diff) * (1 - y_diff) + (b & 0xff) * (x_diff) * (1 - y_diff) +
+                        (c & 0xff) * (y_diff) * (1 - x_diff) + (d & 0xff) * (x_diff * y_diff);
 
                 // Green element
-                green = ((a>>8)&0xff)*(1-x_diff)*(1-y_diff) + ((b>>8)&0xff)*(x_diff)*(1-y_diff) +
-                        ((c>>8)&0xff)*(y_diff)*(1-x_diff)   + ((d>>8)&0xff)*(x_diff*y_diff);
+                green = ((a >> 8) & 0xff) * (1 - x_diff) * (1 - y_diff) + ((b >> 8) & 0xff) * (x_diff) * (1 - y_diff) +
+                        ((c >> 8) & 0xff) * (y_diff) * (1 - x_diff) + ((d >> 8) & 0xff) * (x_diff * y_diff);
 
                 // Red element
-                red = ((a>>16)&0xff)*(1-x_diff)*(1-y_diff) + ((b>>16)&0xff)*(x_diff)*(1-y_diff) +
-                        ((c>>16)&0xff)*(y_diff)*(1-x_diff)   + ((d>>16)&0xff)*(x_diff*y_diff);
+                red = ((a >> 16) & 0xff) * (1 - x_diff) * (1 - y_diff) + ((b >> 16) & 0xff) * (x_diff) * (1 - y_diff) +
+                        ((c >> 16) & 0xff) * (y_diff) * (1 - x_diff) + ((d >> 16) & 0xff) * (x_diff * y_diff);
 
                 result.setColor(j, i,
-                        ((((int)red)<<16)&0xff0000) |
-                                ((((int)green)<<8)&0xff00) |
-                                ((int)blue)&0xff);
+                        ((((int) red) << 16) & 0xff0000) |
+                                ((((int) green) << 8) & 0xff00) |
+                                ((int) blue) & 0xff);
             }
         }
 
         return result;
     }
-    public  static NativeImage invertTexture(NativeImage image) {
+
+    public static NativeImage invertTexture(NativeImage image) {
         int width = image.getWidth();
         int height = image.getHeight();
         NativeImage result = new NativeImage(width, height, false);
@@ -117,8 +119,8 @@ public class TextureHelper {
 
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                int newX = (int)((x - centerX) * Math.cos(angle) - (y - centerY) * Math.sin(angle) + centerX);
-                int newY = (int)((x - centerX) * Math.sin(angle) + (y - centerY) * Math.cos(angle) + centerY);
+                int newX = (int) ((x - centerX) * Math.cos(angle) - (y - centerY) * Math.sin(angle) + centerX);
+                int newY = (int) ((x - centerX) * Math.sin(angle) + (y - centerY) * Math.cos(angle) + centerY);
 
                 if (newX >= 0 && newX < width && newY >= 0 && newY < height) {
                     result.setColor(newY, newX, image.getColor(x, y));
@@ -188,6 +190,7 @@ public class TextureHelper {
 
         return result;
     }
+
     public static NativeImage cropTexture(NativeImage image, int x, int y, int width, int height) {
         NativeImage result = new NativeImage(width, height, false);
 
@@ -263,9 +266,9 @@ public class TextureHelper {
             }
         }
 
-        int redAverage = (int)(redTotal / pixelCount);
-        int greenAverage = (int)(greenTotal / pixelCount);
-        int blueAverage = (int)(blueTotal / pixelCount);
+        int redAverage = (int) (redTotal / pixelCount);
+        int greenAverage = (int) (greenTotal / pixelCount);
+        int blueAverage = (int) (blueTotal / pixelCount);
 
         return (redAverage << 16) | (greenAverage << 8) | blueAverage;
     }

--- a/src/main/java/com/tanishisherewith/dynamichud/screens/AbstractMoveableScreen.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/screens/AbstractMoveableScreen.java
@@ -28,44 +28,50 @@ public abstract class AbstractMoveableScreen extends Screen {
     @Override
     public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
         widgetRenderer.mouseDragged(mouseX, mouseY, button, GlobalConfig.get().getSnapSize());
-        ContextMenuManager.getInstance().handleMouseDragged(mouseX,mouseY,button,deltaX,deltaY);
+        ContextMenuManager.getInstance().mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
         return false;
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if(widgetRenderer.mouseClicked(mouseX, mouseY, button)){
-            handleClickOnWidget(widgetRenderer.selectedWidget,mouseX,mouseY,button);
+        if (widgetRenderer.mouseClicked(mouseX, mouseY, button)) {
+            handleClickOnWidget(widgetRenderer.selectedWidget, mouseX, mouseY, button);
         }
-        ContextMenuManager.getInstance().handleMouseClicked(mouseX,mouseY,button);
+        ContextMenuManager.getInstance().mouseClicked(mouseX, mouseY, button);
         return false;
+    }
+
+    @Override
+    public boolean charTyped(char chr, int modifiers) {
+        ContextMenuManager.getInstance().charTyped(chr);
+        return super.charTyped(chr, modifiers);
     }
 
     @Override
     public boolean mouseReleased(double mouseX, double mouseY, int button) {
         widgetRenderer.mouseReleased(mouseX, mouseY, button);
-        ContextMenuManager.getInstance().handleMouseReleased(mouseX,mouseY,button);
+        ContextMenuManager.getInstance().mouseReleased(mouseX, mouseY, button);
         return false;
     }
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
         widgetRenderer.keyPressed(keyCode);
-        ContextMenuManager.getInstance().handleKeyPressed(keyCode, scanCode, modifiers);
+        ContextMenuManager.getInstance().keyPressed(keyCode, scanCode, modifiers);
         return super.keyPressed(keyCode, scanCode, modifiers);
     }
 
     @Override
     public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
         widgetRenderer.keyReleased(keyCode);
-        ContextMenuManager.getInstance().handleKeyReleased(keyCode, scanCode, modifiers);
+        ContextMenuManager.getInstance().keyReleased(keyCode, scanCode, modifiers);
         return super.keyReleased(keyCode, scanCode, modifiers);
     }
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
         widgetRenderer.mouseScrolled(mouseX, mouseY, verticalAmount, horizontalAmount);
-        ContextMenuManager.getInstance().handleMouseScrolled(mouseX, mouseY, horizontalAmount,verticalAmount);
+        ContextMenuManager.getInstance().mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
         return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
     }
 
@@ -83,14 +89,14 @@ public abstract class AbstractMoveableScreen extends Screen {
         if (this.client.world == null) {
             renderInGameBackground(drawContext);
         }
-        drawContext.drawText(client.textRenderer,title,client.getWindow().getScaledWidth()/2 - client.textRenderer.getWidth(title.getString())/2,textRenderer.fontHeight/2,-1,true);
+        drawContext.drawText(client.textRenderer, title, client.getWindow().getScaledWidth() / 2 - client.textRenderer.getWidth(title.getString()) / 2, textRenderer.fontHeight / 2, -1, true);
 
         // Draw each widget
         widgetRenderer.renderWidgets(drawContext, mouseX, mouseY);
 
-        ContextMenuManager.getInstance().renderAll(drawContext,mouseX,mouseY);
+        ContextMenuManager.getInstance().renderAll(drawContext, mouseX, mouseY);
 
-        if(GlobalConfig.get().shouldDisplayDescriptions()) {
+        if (GlobalConfig.get().shouldDisplayDescriptions()) {
             for (Widget widget : widgetRenderer.getWidgets()) {
                 if (widget == null || widget.shiftDown) continue;
 
@@ -101,7 +107,8 @@ public abstract class AbstractMoveableScreen extends Screen {
             }
         }
     }
-    public void handleClickOnWidget(Widget widget, double mouseX, double mouseY, int button){
+
+    public void handleClickOnWidget(Widget widget, double mouseX, double mouseY, int button) {
 
     }
 

--- a/src/main/java/com/tanishisherewith/dynamichud/screens/AbstractMoveableScreen.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/screens/AbstractMoveableScreen.java
@@ -10,7 +10,7 @@ import net.minecraft.text.Text;
 
 public abstract class AbstractMoveableScreen extends Screen {
     public final WidgetRenderer widgetRenderer;
-    public int snapSize = 100;
+
     /**
      * Constructs a AbstractMoveableScreen object.
      */
@@ -27,7 +27,7 @@ public abstract class AbstractMoveableScreen extends Screen {
 
     @Override
     public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
-        widgetRenderer.mouseDragged(mouseX, mouseY, button, snapSize);
+        widgetRenderer.mouseDragged(mouseX, mouseY, button, GlobalConfig.get().getSnapSize());
         ContextMenuManager.getInstance().handleMouseDragged(mouseX,mouseY,button,deltaX,deltaY);
         return false;
     }
@@ -116,10 +116,6 @@ public abstract class AbstractMoveableScreen extends Screen {
     @Override
     public boolean shouldPause() {
         return false;
-    }
-
-    public void setSnapSize(int size) {
-        this.snapSize = size;
     }
 }
 

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/BooleanPool.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/BooleanPool.java
@@ -9,6 +9,7 @@ public class BooleanPool {
     public static void put(String key, boolean value) {
         pool.put(key, value);
     }
+
     public static void remove(String key) {
         pool.remove(key);
     }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/Input.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/Input.java
@@ -1,0 +1,22 @@
+package com.tanishisherewith.dynamichud.utils;
+
+
+public interface Input {
+    boolean mouseClicked(double mouseX, double mouseY, int button);
+
+    boolean mouseReleased(double mouseX, double mouseY, int button);
+
+    boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY);
+
+    void keyPressed(int key, int scanCode, int modifiers);
+
+    void keyReleased(int key, int scanCode, int modifiers);
+
+    void mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount);
+
+    default boolean isMouseOver(double mouseX, double mouseY, double x, double y, double width, double height) {
+        return mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height;
+    }
+
+    void charTyped(char c);
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenu.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenu.java
@@ -24,15 +24,15 @@ public class ContextMenu {
     // Width is counted while the options are being rendered.
     // FinalWidth is the width at the end of the count.
     private int width = 0;
-    public int finalWidth = 0;
-    public int height = 0, widgetHeight = 0;
+    private int finalWidth = 0;
+    private int height = 0, widgetHeight = 0;
     //Todo: Add padding around the rectangle instead of just one side.
-    public boolean shouldDisplay = false;
-    public float scale = 0.0f;
+    private boolean shouldDisplay = false;
+    private float scale = 0.0f;
     public final Color darkerBackgroundColor;
-    public boolean newScreenFlag = false;
-    public Screen parentScreen = null;
+    private Screen parentScreen = null;
     private final ContextMenuScreenFactory screenFactory;
+    private boolean newScreenFlag = false;
 
     public ContextMenu(int x, int y, ContextMenuProperties properties) {
         this(x, y, properties, new DefaultContextMenuScreenFactory());
@@ -52,8 +52,8 @@ public class ContextMenu {
     }
 
     public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
-        if(newScreenFlag && screenFactory != null) {
-            DynamicHUD.MC.setScreen(screenFactory.create(this,properties));
+        if (newScreenFlag && screenFactory != null) {
+            DynamicHUD.MC.setScreen(screenFactory.create(this, properties));
             return;
         }
 
@@ -66,35 +66,6 @@ public class ContextMenu {
 
         properties.getSkin().setContextMenu(this);
         properties.getSkin().renderContextMenu(drawContext,this,mouseX,mouseY);
-
-        /*
-        // Draw the background
-        DrawHelper.drawRoundedRectangle(drawContext.getMatrices().peek().getPositionMatrix(),  this.x - 1, this.y, this.width, this.height, 2,properties.getBackgroundColor().getRGB());
-        if(properties.shouldDrawBorder()){
-            DrawHelper.drawOutlineRoundedBox(drawContext.getMatrices().peek().getPositionMatrix(), this.x - 1,this.y,this.width,this.height,2, properties.getBorderWidth(), darkerBorderColor.getRGB());
-        }
-
-        int yOffset = this.y + 3;
-        this.width = 10;
-        for (Option<?> option : options) {
-            if (!option.shouldRender()) continue;
-
-            // Adjust mouse coordinates based on the scale
-            int adjustedMouseX = (int) (mouseX / GlobalConfig.get().getScale());
-            int adjustedMouseY = (int) (mouseY / GlobalConfig.get().getScale());
-
-            if (isMouseOver(adjustedMouseX, adjustedMouseY, this.x + 1, yOffset - 1, this.finalWidth - 2, option.height)) {
-                DrawHelper.drawRoundedRectangle(drawContext.getMatrices().peek().getPositionMatrix(), this.x, yOffset - 1.24f, this.finalWidth - 2, option.height + 0.48f, 2,properties.getBackgroundColor().darker().darker().getRGB());
-            }
-            option.render(drawContext, x + 2, yOffset,mouseX,mouseY);
-            this.width = Math.max(this.width, option.width);
-            yOffset += option.height + 1;
-        }
-        this.width = this.width + properties.getPadding();
-        this.finalWidth = this.width;
-        this.height = (yOffset - this.y);
-
-         */
 
         DrawHelper.stopScaling(drawContext.getMatrices());
     }
@@ -119,7 +90,7 @@ public class ContextMenu {
     }
 
     public void close() {
-        if(newScreenFlag && scale <= 0 && parentScreen != null){
+        if(properties.getSkin().shouldCreateNewScreen() && scale <= 0 && parentScreen != null){
             shouldDisplay = false;
             newScreenFlag = false;
             DynamicHUD.MC.setScreen(parentScreen);
@@ -135,6 +106,9 @@ public class ContextMenu {
         shouldDisplay = true;
         update();
         parentScreen = DynamicHUD.MC.currentScreen;
+        if (properties.getSkin().shouldCreateNewScreen()) {
+            newScreenFlag = true;
+        }
     }
 
     public void toggleDisplay() {
@@ -176,7 +150,6 @@ public class ContextMenu {
         }
 
         properties.getSkin().keyPressed(this,key,scanCode,modifiers);
-
     }
 
     public void keyReleased(int key, int scanCode, int modifiers) {
@@ -233,5 +206,24 @@ public class ContextMenu {
 
     public ContextMenuProperties getProperties() {
         return properties;
+    }
+    public void setWidgetHeight(int widgetHeight) {
+        this.widgetHeight = widgetHeight;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public float getScale() {
+        return scale;
+    }
+
+    public void setVisible(boolean shouldDisplay) {
+        this.shouldDisplay = shouldDisplay;
+    }
+
+    public boolean isVisible() {
+        return shouldDisplay;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenu.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenu.java
@@ -1,66 +1,100 @@
 package com.tanishisherewith.dynamichud.utils.contextmenu;
 
+import com.tanishisherewith.dynamichud.DynamicHUD;
 import com.tanishisherewith.dynamichud.helpers.DrawHelper;
+import com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen.ContextMenuScreen;
+import com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen.ContextMenuScreenFactory;
+import com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen.DefaultContextMenuScreenFactory;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.util.math.MathHelper;
 
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class ContextMenu {
+
+    //The properties of a context menu
+    protected final ContextMenuProperties properties;
+
     private final List<Option<?>> options = new ArrayList<>(); // The list of options in the context menu
     public int x, y;
     // Width is counted while the options are being rendered.
     // FinalWidth is the width at the end of the count.
     private int width = 0;
     public int finalWidth = 0;
-    public int height = 0;
-    public Color backgroundColor = new Color(107, 112, 126, 124);
-    private final Color darkerBorderColor = backgroundColor.darker().darker().darker().darker().darker().darker();
+    public int height = 0, widgetHeight = 0;
     //Todo: Add padding around the rectangle instead of just one side.
-    public int padding = 5; // The amount of padding around the rectangle
-    public int heightOffset = 4; // Height offset from the widget
     public boolean shouldDisplay = false;
-    public static boolean drawBorder = true;
-    protected float scale = 0.0f;
+    public float scale = 0.0f;
+    public final Color darkerBackgroundColor;
+    public boolean newScreenFlag = false;
+    public Screen parentScreen = null;
+    private final ContextMenuScreenFactory screenFactory;
 
-    public ContextMenu(int x, int y) {
+    public ContextMenu(int x, int y, ContextMenuProperties properties) {
+        this(x, y, properties, new DefaultContextMenuScreenFactory());
+    }
+
+    public ContextMenu(int x, int y, ContextMenuProperties properties, ContextMenuScreenFactory screenFactory) {
         this.x = x;
-        this.y = y + heightOffset;
+        this.y = y + properties.getHeightOffset();
+        this.properties = properties;
+        this.screenFactory = screenFactory;
+        darkerBackgroundColor = properties.getBackgroundColor().darker().darker().darker().darker().darker().darker();
     }
 
     public void addOption(Option<?> option) {
+        option.updateProperties(this.getProperties());
         options.add(option);
     }
 
-    public void render(DrawContext drawContext, int x, int y, int height, int mouseX, int mouseY) {
-        this.x = x;
-        this.y = y + heightOffset + height;
-        if (!shouldDisplay) return;
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
+        if(newScreenFlag && screenFactory != null) {
+            DynamicHUD.MC.setScreen(screenFactory.create(this,properties));
+            return;
+        }
 
+        this.x = x;
+        this.y = y + properties.getHeightOffset() + widgetHeight;
         update();
+        if (scale <= 0.0f || newScreenFlag) return;
+
         DrawHelper.scaleAndPosition(drawContext.getMatrices(), x, y, scale);
 
+        properties.getSkin().setContextMenu(this);
+        properties.getSkin().renderContextMenu(drawContext,this,mouseX,mouseY);
+
+        /*
         // Draw the background
-        DrawHelper.drawRoundedRectangle(drawContext.getMatrices().peek().getPositionMatrix(),  this.x - 1, this.y, this.width, this.height, 2,backgroundColor.getRGB());
-        if(drawBorder){
-            DrawHelper.drawOutlineRoundedBox(drawContext.getMatrices().peek().getPositionMatrix(), this.x - 1,this.y,this.width,this.height,2,0.7f,darkerBorderColor.getRGB());
+        DrawHelper.drawRoundedRectangle(drawContext.getMatrices().peek().getPositionMatrix(),  this.x - 1, this.y, this.width, this.height, 2,properties.getBackgroundColor().getRGB());
+        if(properties.shouldDrawBorder()){
+            DrawHelper.drawOutlineRoundedBox(drawContext.getMatrices().peek().getPositionMatrix(), this.x - 1,this.y,this.width,this.height,2, properties.getBorderWidth(), darkerBorderColor.getRGB());
         }
 
         int yOffset = this.y + 3;
         this.width = 10;
         for (Option<?> option : options) {
             if (!option.shouldRender()) continue;
-            if(isMouseOver(mouseX,mouseY, this.x +1,yOffset-1,this.finalWidth - 2,option.height)){
-               DrawHelper.drawRoundedRectangle(drawContext.getMatrices().peek().getPositionMatrix(), this.x,yOffset - 1.24f,this.finalWidth - 2,option.height + 0.48f,2,backgroundColor.darker().darker().getRGB());
+
+            // Adjust mouse coordinates based on the scale
+            int adjustedMouseX = (int) (mouseX / GlobalConfig.get().getScale());
+            int adjustedMouseY = (int) (mouseY / GlobalConfig.get().getScale());
+
+            if (isMouseOver(adjustedMouseX, adjustedMouseY, this.x + 1, yOffset - 1, this.finalWidth - 2, option.height)) {
+                DrawHelper.drawRoundedRectangle(drawContext.getMatrices().peek().getPositionMatrix(), this.x, yOffset - 1.24f, this.finalWidth - 2, option.height + 0.48f, 2,properties.getBackgroundColor().darker().darker().getRGB());
             }
             option.render(drawContext, x + 2, yOffset,mouseX,mouseY);
             this.width = Math.max(this.width, option.width);
             yOffset += option.height + 1;
         }
-        this.width = this.width + padding;
+        this.width = this.width + properties.getPadding();
         this.finalWidth = this.width;
         this.height = (yOffset - this.y);
+
+         */
 
         DrawHelper.stopScaling(drawContext.getMatrices());
     }
@@ -69,22 +103,38 @@ public class ContextMenu {
     }
 
     public void update() {
-        // Update the scale
-        float scaleSpeed = 0.1f;
-        scale += scaleSpeed;
-        if (scale > 1.0f) {
+        if(!properties.enableAnimations()){
             scale = 1.0f;
+            return;
         }
+
+        // Update the scale
+        if(shouldDisplay){
+           scale += 0.1f;
+        } else{
+           scale -= 0.1f;
+        }
+
+        scale = MathHelper.clamp(scale,0,1.0f);
     }
 
     public void close() {
+        if(newScreenFlag && scale <= 0 && parentScreen != null){
+            shouldDisplay = false;
+            newScreenFlag = false;
+            DynamicHUD.MC.setScreen(parentScreen);
+        }
+        for(Option<?> option: options){
+            option.onClose();
+        }
         shouldDisplay = false;
-        scale = 0.0f;
+        newScreenFlag = false;
     }
 
     public void open() {
         shouldDisplay = true;
         update();
+        parentScreen = DynamicHUD.MC.currentScreen;
     }
 
     public void toggleDisplay() {
@@ -100,6 +150,7 @@ public class ContextMenu {
         for (Option<?> option : options) {
             option.mouseClicked(mouseX, mouseY, button);
         }
+        properties.getSkin().mouseClicked(this,mouseX,mouseY,button);
     }
 
     public void mouseReleased(double mouseX, double mouseY, int button) {
@@ -107,27 +158,47 @@ public class ContextMenu {
         for (Option<?> option : options) {
             option.mouseReleased(mouseX, mouseY, button);
         }
+        properties.getSkin().mouseReleased(this,mouseX,mouseY,button);
     }
 
-    public void mouseDragged(double mouseX, double mouseY, int button) {
+    public void mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
         if (!shouldDisplay) return;
         for (Option<?> option : options) {
-            option.mouseDragged(mouseX, mouseY, button);
+            option.mouseDragged(mouseX, mouseY, button,deltaX,deltaY);
         }
+        properties.getSkin().mouseDragged(this,mouseX,mouseY,button,deltaX,deltaY);
     }
 
-    public void keyPressed(int key) {
+    public void keyPressed(int key, int scanCode, int modifiers) {
         if (!shouldDisplay) return;
         for (Option<?> option : options) {
             option.keyPressed(key);
         }
+
+        properties.getSkin().keyPressed(this,key,scanCode,modifiers);
+
     }
 
-    public void keyReleased(int key) {
+    public void keyReleased(int key, int scanCode, int modifiers) {
         if (!shouldDisplay) return;
         for (Option<?> option : options) {
             option.keyReleased(key);
         }
+        properties.getSkin().keyReleased(this,key,scanCode,modifiers);
+
+    }
+
+    public void mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+        for(Option<?> option: options){
+            option.mouseScrolled(mouseX,mouseY,horizontalAmount,verticalAmount);
+        }
+        properties.getSkin().mouseScrolled(this,mouseX,mouseY,horizontalAmount,verticalAmount);
+    }
+
+    public void set(int x,int y, int widgetHeight){
+        this.x = x;
+        this.y = y;
+        this.widgetHeight = widgetHeight;
     }
 
     public int getX() {
@@ -138,14 +209,29 @@ public class ContextMenu {
         return y;
     }
     public List<Option<?>> getOptions() {
-        return options;
+        return Collections.unmodifiableList(options);
     }
 
     public int getHeight() {
         return height;
     }
 
-    public int getWidth() {
+    public int getFinalWidth() {
         return finalWidth;
+    }
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public void setFinalWidth(int finalWidth) {
+        this.finalWidth = finalWidth;
+    }
+
+    public ContextMenuProperties getProperties() {
+        return properties;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenu.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenu.java
@@ -2,7 +2,7 @@ package com.tanishisherewith.dynamichud.utils.contextmenu;
 
 import com.tanishisherewith.dynamichud.DynamicHUD;
 import com.tanishisherewith.dynamichud.helpers.DrawHelper;
-import com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen.ContextMenuScreen;
+import com.tanishisherewith.dynamichud.utils.Input;
 import com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen.ContextMenuScreenFactory;
 import com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen.DefaultContextMenuScreenFactory;
 import net.minecraft.client.gui.DrawContext;
@@ -14,12 +14,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class ContextMenu {
+public class ContextMenu implements Input {
 
+    public final Color darkerBackgroundColor;
     //The properties of a context menu
     protected final ContextMenuProperties properties;
-
     private final List<Option<?>> options = new ArrayList<>(); // The list of options in the context menu
+    private final ContextMenuScreenFactory screenFactory;
     public int x, y;
     // Width is counted while the options are being rendered.
     // FinalWidth is the width at the end of the count.
@@ -28,9 +29,7 @@ public class ContextMenu {
     private int height = 0, widgetHeight = 0;
     private boolean shouldDisplay = false;
     private float scale = 0.0f;
-    public final Color darkerBackgroundColor;
     private Screen parentScreen = null;
-    private final ContextMenuScreenFactory screenFactory;
     private boolean newScreenFlag = false;
 
     public ContextMenu(int x, int y, ContextMenuProperties properties) {
@@ -64,37 +63,34 @@ public class ContextMenu {
         DrawHelper.scaleAndPosition(drawContext.getMatrices(), x, y, scale);
 
         properties.getSkin().setContextMenu(this);
-        properties.getSkin().renderContextMenu(drawContext,this,mouseX,mouseY);
+        properties.getSkin().renderContextMenu(drawContext, this, mouseX, mouseY);
 
         DrawHelper.stopScaling(drawContext.getMatrices());
     }
-    public boolean isMouseOver(int mouseX, int mouseY, int x, int y, int width, int height){
-        return mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height;
-    }
 
     public void update() {
-        if(!properties.enableAnimations()){
+        if (!properties.enableAnimations()) {
             scale = 1.0f;
             return;
         }
 
         // Update the scale
-        if(shouldDisplay){
-           scale += 0.1f;
-        } else{
-           scale -= 0.1f;
+        if (shouldDisplay) {
+            scale += 0.1f;
+        } else {
+            scale -= 0.1f;
         }
 
-        scale = MathHelper.clamp(scale,0,1.0f);
+        scale = MathHelper.clamp(scale, 0, 1.0f);
     }
 
     public void close() {
-        if(properties.getSkin().shouldCreateNewScreen() && scale <= 0 && parentScreen != null){
+        if (properties.getSkin().shouldCreateNewScreen() && scale <= 0 && parentScreen != null) {
             shouldDisplay = false;
             newScreenFlag = false;
             DynamicHUD.MC.setScreen(parentScreen);
         }
-        for(Option<?> option: options){
+        for (Option<?> option : options) {
             option.onClose();
         }
         shouldDisplay = false;
@@ -118,56 +114,67 @@ public class ContextMenu {
         }
     }
 
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        if (!shouldDisplay) return;
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (!shouldDisplay) return false;
         for (Option<?> option : options) {
             option.mouseClicked(mouseX, mouseY, button);
         }
-        properties.getSkin().mouseClicked(this,mouseX,mouseY,button);
+        return properties.getSkin().mouseClicked(this, mouseX, mouseY, button);
     }
 
-    public void mouseReleased(double mouseX, double mouseY, int button) {
-        if (!shouldDisplay) return;
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        if (!shouldDisplay) return false;
         for (Option<?> option : options) {
             option.mouseReleased(mouseX, mouseY, button);
         }
-        properties.getSkin().mouseReleased(this,mouseX,mouseY,button);
+        return properties.getSkin().mouseReleased(this, mouseX, mouseY, button);
     }
 
-    public void mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
-        if (!shouldDisplay) return;
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        if (!shouldDisplay) return false;
         for (Option<?> option : options) {
-            option.mouseDragged(mouseX, mouseY, button,deltaX,deltaY);
+            option.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
         }
-        properties.getSkin().mouseDragged(this,mouseX,mouseY,button,deltaX,deltaY);
+        return properties.getSkin().mouseDragged(this, mouseX, mouseY, button, deltaX, deltaY);
     }
 
+    @Override
     public void keyPressed(int key, int scanCode, int modifiers) {
         if (!shouldDisplay) return;
         for (Option<?> option : options) {
-            option.keyPressed(key);
+            option.keyPressed(key, scanCode, modifiers);
         }
 
-        properties.getSkin().keyPressed(this,key,scanCode,modifiers);
+        properties.getSkin().keyPressed(this, key, scanCode, modifiers);
     }
 
+    @Override
     public void keyReleased(int key, int scanCode, int modifiers) {
         if (!shouldDisplay) return;
         for (Option<?> option : options) {
-            option.keyReleased(key);
+            option.keyReleased(key, scanCode, modifiers);
         }
-        properties.getSkin().keyReleased(this,key,scanCode,modifiers);
+        properties.getSkin().keyReleased(this, key, scanCode, modifiers);
 
     }
 
+    @Override
     public void mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-        for(Option<?> option: options){
-            option.mouseScrolled(mouseX,mouseY,horizontalAmount,verticalAmount);
+        for (Option<?> option : options) {
+            option.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
         }
-        properties.getSkin().mouseScrolled(this,mouseX,mouseY,horizontalAmount,verticalAmount);
+        properties.getSkin().mouseScrolled(this, mouseX, mouseY, horizontalAmount, verticalAmount);
     }
 
-    public void set(int x,int y, int widgetHeight){
+    @Override
+    public void charTyped(char c) {
+
+    }
+
+    public void set(int x, int y, int widgetHeight) {
         this.x = x;
         this.y = y;
         this.widgetHeight = widgetHeight;
@@ -180,6 +187,7 @@ public class ContextMenu {
     public int getY() {
         return y;
     }
+
     public List<Option<?>> getOptions() {
         return Collections.unmodifiableList(options);
     }
@@ -188,9 +196,18 @@ public class ContextMenu {
         return height;
     }
 
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
     public int getFinalWidth() {
         return finalWidth;
     }
+
+    public void setFinalWidth(int finalWidth) {
+        this.finalWidth = finalWidth;
+    }
+
     public int getWidth() {
         return width;
     }
@@ -199,30 +216,23 @@ public class ContextMenu {
         this.width = width;
     }
 
-    public void setFinalWidth(int finalWidth) {
-        this.finalWidth = finalWidth;
-    }
-
     public ContextMenuProperties getProperties() {
         return properties;
     }
+
     public void setWidgetHeight(int widgetHeight) {
         this.widgetHeight = widgetHeight;
-    }
-
-    public void setHeight(int height) {
-        this.height = height;
     }
 
     public float getScale() {
         return scale;
     }
 
-    public void setVisible(boolean shouldDisplay) {
-        this.shouldDisplay = shouldDisplay;
-    }
-
     public boolean isVisible() {
         return shouldDisplay;
+    }
+
+    public void setVisible(boolean shouldDisplay) {
+        this.shouldDisplay = shouldDisplay;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenu.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenu.java
@@ -26,7 +26,6 @@ public class ContextMenu {
     private int width = 0;
     private int finalWidth = 0;
     private int height = 0, widgetHeight = 0;
-    //Todo: Add padding around the rectangle instead of just one side.
     private boolean shouldDisplay = false;
     private float scale = 0.0f;
     public final Color darkerBackgroundColor;

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuManager.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuManager.java
@@ -1,17 +1,17 @@
 package com.tanishisherewith.dynamichud.utils.contextmenu;
 
+import com.tanishisherewith.dynamichud.utils.Input;
 import net.minecraft.client.gui.DrawContext;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-public class ContextMenuManager {
+public class ContextMenuManager implements Input {
     private static final ContextMenuManager INSTANCE = new ContextMenuManager();
     private final List<ContextMenuProvider> providers = new ArrayList<>();
 
-    private ContextMenuManager() {}
+    private ContextMenuManager() {
+    }
 
     public static ContextMenuManager getInstance() {
         return INSTANCE;
@@ -30,34 +30,47 @@ public class ContextMenuManager {
         }
     }
 
-    public void handleMouseClicked(double mouseX, double mouseY, int button) {
+    public void onClose() {
+        for (ContextMenuProvider provider : providers) {
+            provider.getContextMenu().close();
+        }
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
         for (ContextMenuProvider provider : providers) {
             ContextMenu contextMenu = provider.getContextMenu();
             if (contextMenu != null) {
                 contextMenu.mouseClicked(mouseX, mouseY, button);
             }
         }
+        return false;
     }
 
-    public void handleMouseReleased(double mouseX, double mouseY, int button) {
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
         for (ContextMenuProvider provider : providers) {
             ContextMenu contextMenu = provider.getContextMenu();
             if (contextMenu != null) {
                 contextMenu.mouseReleased(mouseX, mouseY, button);
             }
         }
+        return false;
     }
 
-    public void handleMouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
         for (ContextMenuProvider provider : providers) {
             ContextMenu contextMenu = provider.getContextMenu();
             if (contextMenu != null) {
                 contextMenu.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
             }
         }
+        return false;
     }
 
-    public void handleKeyPressed(int key, int scanCode, int modifiers) {
+    @Override
+    public void keyPressed(int key, int scanCode, int modifiers) {
         for (ContextMenuProvider provider : providers) {
             ContextMenu contextMenu = provider.getContextMenu();
             if (contextMenu != null) {
@@ -66,7 +79,8 @@ public class ContextMenuManager {
         }
     }
 
-    public void handleKeyReleased(int key, int scanCode, int modifiers) {
+    @Override
+    public void keyReleased(int key, int scanCode, int modifiers) {
         for (ContextMenuProvider provider : providers) {
             ContextMenu contextMenu = provider.getContextMenu();
             if (contextMenu != null) {
@@ -75,7 +89,8 @@ public class ContextMenuManager {
         }
     }
 
-    public void handleMouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+    @Override
+    public void mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
         for (ContextMenuProvider provider : providers) {
             ContextMenu contextMenu = provider.getContextMenu();
             if (contextMenu != null) {
@@ -83,9 +98,14 @@ public class ContextMenuManager {
             }
         }
     }
-    public void onClose(){
-        for(ContextMenuProvider provider: providers){
-            provider.getContextMenu().close();
+
+    @Override
+    public void charTyped(char c) {
+        for (ContextMenuProvider provider : providers) {
+            ContextMenu contextMenu = provider.getContextMenu();
+            if (contextMenu != null) {
+                contextMenu.charTyped(c);
+            }
         }
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuManager.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuManager.java
@@ -1,0 +1,91 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu;
+
+import net.minecraft.client.gui.DrawContext;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ContextMenuManager {
+    private static final ContextMenuManager INSTANCE = new ContextMenuManager();
+    private final List<ContextMenuProvider> providers = new ArrayList<>();
+
+    private ContextMenuManager() {}
+
+    public static ContextMenuManager getInstance() {
+        return INSTANCE;
+    }
+
+    public void registerProvider(ContextMenuProvider provider) {
+        providers.add(provider);
+    }
+
+    public void renderAll(DrawContext drawContext, int mouseX, int mouseY) {
+        for (ContextMenuProvider provider : providers) {
+            ContextMenu contextMenu = provider.getContextMenu();
+            if (contextMenu != null) {
+                contextMenu.render(drawContext, contextMenu.getX(), contextMenu.getY(), mouseX, mouseY);
+            }
+        }
+    }
+
+    public void handleMouseClicked(double mouseX, double mouseY, int button) {
+        for (ContextMenuProvider provider : providers) {
+            ContextMenu contextMenu = provider.getContextMenu();
+            if (contextMenu != null) {
+                contextMenu.mouseClicked(mouseX, mouseY, button);
+            }
+        }
+    }
+
+    public void handleMouseReleased(double mouseX, double mouseY, int button) {
+        for (ContextMenuProvider provider : providers) {
+            ContextMenu contextMenu = provider.getContextMenu();
+            if (contextMenu != null) {
+                contextMenu.mouseReleased(mouseX, mouseY, button);
+            }
+        }
+    }
+
+    public void handleMouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        for (ContextMenuProvider provider : providers) {
+            ContextMenu contextMenu = provider.getContextMenu();
+            if (contextMenu != null) {
+                contextMenu.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
+            }
+        }
+    }
+
+    public void handleKeyPressed(int key, int scanCode, int modifiers) {
+        for (ContextMenuProvider provider : providers) {
+            ContextMenu contextMenu = provider.getContextMenu();
+            if (contextMenu != null) {
+                contextMenu.keyPressed(key, scanCode, modifiers);
+            }
+        }
+    }
+
+    public void handleKeyReleased(int key, int scanCode, int modifiers) {
+        for (ContextMenuProvider provider : providers) {
+            ContextMenu contextMenu = provider.getContextMenu();
+            if (contextMenu != null) {
+                contextMenu.keyReleased(key, scanCode, modifiers);
+            }
+        }
+    }
+
+    public void handleMouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+        for (ContextMenuProvider provider : providers) {
+            ContextMenu contextMenu = provider.getContextMenu();
+            if (contextMenu != null) {
+                contextMenu.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
+            }
+        }
+    }
+    public void onClose(){
+        for(ContextMenuProvider provider: providers){
+            provider.getContextMenu().close();
+        }
+    }
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuProperties.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuProperties.java
@@ -1,0 +1,181 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu;
+
+import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.ClassicSkin;
+import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.MinecraftSkin;
+import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.Skin;
+
+import java.awt.*;
+
+public class ContextMenuProperties {
+    private Color backgroundColor = new Color(107, 112, 126, 124);
+    private Color borderColor = Color.BLACK;
+    private float borderWidth = 1f;
+    private int padding = 5;  // The amount of padding around the rectangle
+    private int heightOffset = 4; // Height offset from the widget
+    private boolean drawBorder = true;
+    private boolean shadow = false;
+    private boolean roundedCorners = true;
+    private int cornerRadius = 3;
+    private boolean hoverEffect = true;
+    private Color hoverColor = new Color(42, 42, 42, 150);
+    private boolean enableAnimations = true;
+    private Skin skin = new ClassicSkin();
+
+    private ContextMenuProperties() {}
+
+    public static Builder builder() {
+        return new ContextMenuProperties().new Builder();
+    }
+
+    public static ContextMenuProperties createGenericSimplified() {
+        return new ContextMenuProperties().new Builder().build();
+    }
+
+    public class Builder {
+        private Builder() {}
+
+        public Builder backgroundColor(Color backgroundColor) {
+            ContextMenuProperties.this.backgroundColor = backgroundColor;
+            return this;
+        }
+
+        public Builder borderColor(Color borderColor) {
+            ContextMenuProperties.this.borderColor = borderColor;
+            return this;
+        }
+
+        public Builder skin(Skin skin) {
+            ContextMenuProperties.this.skin = skin;
+            return this;
+        }
+
+        public Builder borderWidth(float borderWidth) {
+            ContextMenuProperties.this.borderWidth = borderWidth;
+            return this;
+        }
+
+        public Builder padding(int padding) {
+            ContextMenuProperties.this.padding = padding;
+            return this;
+        }
+
+        public Builder heightOffset(int heightOffset) {
+            ContextMenuProperties.this.heightOffset = heightOffset;
+            return this;
+        }
+
+        public Builder drawBorder(boolean drawBorder) {
+            ContextMenuProperties.this.drawBorder = drawBorder;
+            return this;
+        }
+
+        public Builder shadow(boolean shadow) {
+            ContextMenuProperties.this.shadow = shadow;
+            return this;
+        }
+
+        public Builder roundedCorners(boolean roundedCorners) {
+            ContextMenuProperties.this.roundedCorners = roundedCorners;
+            return this;
+        }
+
+        public Builder cornerRadius(int cornerRadius) {
+            ContextMenuProperties.this.cornerRadius = cornerRadius;
+            return this;
+        }
+
+        public Builder hoverEffect(boolean hoverEffect) {
+            ContextMenuProperties.this.hoverEffect = hoverEffect;
+            return this;
+        }
+
+        public Builder hoverColor(Color hoverColor) {
+            ContextMenuProperties.this.hoverColor = hoverColor;
+            return this;
+        }
+
+        public Builder enableAnimations(boolean enableAnimations) {
+            ContextMenuProperties.this.enableAnimations = enableAnimations;
+            return this;
+        }
+
+        public ContextMenuProperties build() {
+            return ContextMenuProperties.this;
+        }
+    }
+
+    // Getters for all properties
+    public Color getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public Color getBorderColor() {
+        return borderColor;
+    }
+
+    public float getBorderWidth() {
+        return borderWidth;
+    }
+
+    public int getPadding() {
+        return padding;
+    }
+
+    public int getHeightOffset() {
+        return heightOffset;
+    }
+
+    public boolean shouldDrawBorder() {
+        return drawBorder;
+    }
+
+    public boolean shadow() {
+        return shadow;
+    }
+
+    public boolean roundedCorners() {
+        return roundedCorners;
+    }
+
+    public int getCornerRadius() {
+        return cornerRadius;
+    }
+
+    public boolean hoverEffect() {
+        return hoverEffect;
+    }
+
+    public Color getHoverColor() {
+        return hoverColor;
+    }
+
+    public boolean enableAnimations() {
+        return enableAnimations;
+    }
+
+    public Skin getSkin() {
+        return skin;
+    }
+
+    public void setHeightOffset(int heightOffset) {
+        this.heightOffset = heightOffset;
+    }
+
+    public ContextMenuProperties copy(){
+        return ContextMenuProperties.builder()
+                .backgroundColor(backgroundColor)
+                .borderColor(borderColor)
+                .borderWidth(borderWidth)
+                .padding(padding)
+                .heightOffset(heightOffset)
+                .drawBorder(drawBorder)
+                .shadow(shadow)
+                .roundedCorners(roundedCorners)
+                .cornerRadius(cornerRadius)
+                .hoverEffect(hoverEffect)
+                .hoverColor(hoverColor)
+                .skin(skin)
+                .enableAnimations(enableAnimations)
+                .build();
+    }
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuProperties.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuProperties.java
@@ -1,7 +1,6 @@
 package com.tanishisherewith.dynamichud.utils.contextmenu;
 
 import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.ClassicSkin;
-import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.MinecraftSkin;
 import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.Skin;
 
 import java.awt.*;
@@ -21,7 +20,8 @@ public class ContextMenuProperties {
     private boolean enableAnimations = true;
     private Skin skin = new ClassicSkin();
 
-    private ContextMenuProperties() {}
+    private ContextMenuProperties() {
+    }
 
     public static Builder builder() {
         return new ContextMenuProperties().new Builder();
@@ -31,8 +31,84 @@ public class ContextMenuProperties {
         return new ContextMenuProperties().new Builder().build();
     }
 
+    // Getters for all properties
+    public Color getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public Color getBorderColor() {
+        return borderColor;
+    }
+
+    public float getBorderWidth() {
+        return borderWidth;
+    }
+
+    public int getPadding() {
+        return padding;
+    }
+
+    public int getHeightOffset() {
+        return heightOffset;
+    }
+
+    public void setHeightOffset(int heightOffset) {
+        this.heightOffset = heightOffset;
+    }
+
+    public boolean shouldDrawBorder() {
+        return drawBorder;
+    }
+
+    public boolean shadow() {
+        return shadow;
+    }
+
+    public boolean roundedCorners() {
+        return roundedCorners;
+    }
+
+    public int getCornerRadius() {
+        return cornerRadius;
+    }
+
+    public boolean hoverEffect() {
+        return hoverEffect;
+    }
+
+    public Color getHoverColor() {
+        return hoverColor;
+    }
+
+    public boolean enableAnimations() {
+        return enableAnimations;
+    }
+
+    public Skin getSkin() {
+        return skin;
+    }
+
+    public ContextMenuProperties copy() {
+        return ContextMenuProperties.builder()
+                .backgroundColor(backgroundColor)
+                .borderColor(borderColor)
+                .borderWidth(borderWidth)
+                .padding(padding)
+                .heightOffset(heightOffset)
+                .drawBorder(drawBorder)
+                .shadow(shadow)
+                .roundedCorners(roundedCorners)
+                .cornerRadius(cornerRadius)
+                .hoverEffect(hoverEffect)
+                .hoverColor(hoverColor)
+                .skin(skin)
+                .enableAnimations(enableAnimations)
+                .build();
+    }
+
     public class Builder {
-        private Builder() {}
+        private Builder() {
+        }
 
         public Builder backgroundColor(Color backgroundColor) {
             ContextMenuProperties.this.backgroundColor = backgroundColor;
@@ -102,80 +178,5 @@ public class ContextMenuProperties {
         public ContextMenuProperties build() {
             return ContextMenuProperties.this;
         }
-    }
-
-    // Getters for all properties
-    public Color getBackgroundColor() {
-        return backgroundColor;
-    }
-
-    public Color getBorderColor() {
-        return borderColor;
-    }
-
-    public float getBorderWidth() {
-        return borderWidth;
-    }
-
-    public int getPadding() {
-        return padding;
-    }
-
-    public int getHeightOffset() {
-        return heightOffset;
-    }
-
-    public boolean shouldDrawBorder() {
-        return drawBorder;
-    }
-
-    public boolean shadow() {
-        return shadow;
-    }
-
-    public boolean roundedCorners() {
-        return roundedCorners;
-    }
-
-    public int getCornerRadius() {
-        return cornerRadius;
-    }
-
-    public boolean hoverEffect() {
-        return hoverEffect;
-    }
-
-    public Color getHoverColor() {
-        return hoverColor;
-    }
-
-    public boolean enableAnimations() {
-        return enableAnimations;
-    }
-
-    public Skin getSkin() {
-        return skin;
-    }
-
-    public void setHeightOffset(int heightOffset) {
-        this.heightOffset = heightOffset;
-    }
-
-    public ContextMenuProperties copy(){
-        return ContextMenuProperties.builder()
-                .backgroundColor(backgroundColor)
-                .borderColor(borderColor)
-                .borderWidth(borderWidth)
-                .padding(padding)
-                .heightOffset(heightOffset)
-                .drawBorder(drawBorder)
-                .shadow(shadow)
-                .roundedCorners(roundedCorners)
-                .cornerRadius(cornerRadius)
-                .hoverEffect(hoverEffect)
-                .hoverColor(hoverColor)
-                .skin(skin)
-                .enableAnimations(enableAnimations)
-                .build();
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuProvider.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/ContextMenuProvider.java
@@ -1,0 +1,6 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu;
+
+public interface ContextMenuProvider {
+    ContextMenu getContextMenu();
+}
+

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/Option.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/Option.java
@@ -9,12 +9,11 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public abstract class Option<T> {
-    public int x, y;
-    public int width = 0;
-    public int height = 0;
+    protected int x, y;
+    protected int width = 0;
+    protected int height = 0;
     public T value = null;
-    public Supplier<Boolean> shouldRender = () -> true;
-    protected float scale = 0.0f;
+    protected Supplier<Boolean> shouldRender = () -> true;
     protected Supplier<T> getter;
     protected Consumer<T> setter;
     protected T defaultValue = null;
@@ -106,5 +105,41 @@ public abstract class Option<T> {
 
     public ContextMenuProperties getProperties() {
         return properties;
+    }
+
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+    public void set(int x, int y){
+        this.x = x;
+        this.y = y;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/Option.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/Option.java
@@ -1,19 +1,20 @@
 package com.tanishisherewith.dynamichud.utils.contextmenu;
 
+import com.tanishisherewith.dynamichud.DynamicHUD;
+import com.tanishisherewith.dynamichud.utils.Input;
 import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.SkinRenderer;
-import com.tanishisherewith.dynamichud.widget.Widget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public abstract class Option<T> {
+public abstract class Option<T> implements Input {
+    public T value = null;
     protected int x, y;
     protected int width = 0;
     protected int height = 0;
-    public T value = null;
-    protected Supplier<Boolean> shouldRender = () -> true;
+    protected Supplier<Boolean> shouldRender;
     protected Supplier<T> getter;
     protected Consumer<T> setter;
     protected T defaultValue = null;
@@ -22,10 +23,10 @@ public abstract class Option<T> {
     protected SkinRenderer<Option<T>> renderer;
 
     public Option(Supplier<T> getter, Consumer<T> setter) {
-        this(getter,setter,()->true);
+        this(getter, setter, () -> true);
     }
 
-    public Option(Supplier<T> getter, Consumer<T> setter, Supplier<Boolean> shouldRender,ContextMenuProperties properties) {
+    public Option(Supplier<T> getter, Consumer<T> setter, Supplier<Boolean> shouldRender, ContextMenuProperties properties) {
         this.getter = getter;
         this.setter = setter;
         this.shouldRender = shouldRender;
@@ -35,7 +36,7 @@ public abstract class Option<T> {
     }
 
     public Option(Supplier<T> getter, Consumer<T> setter, Supplier<Boolean> shouldRender) {
-       this(getter,setter,shouldRender,ContextMenuProperties.createGenericSimplified());
+        this(getter, setter, shouldRender, ContextMenuProperties.createGenericSimplified());
     }
 
     public T get() {
@@ -47,16 +48,16 @@ public abstract class Option<T> {
         setter.accept(value);
     }
 
-    public void updateProperties(ContextMenuProperties properties){
+    public void updateProperties(ContextMenuProperties properties) {
         this.properties = properties;
         this.renderer = properties.getSkin().getRenderer((Class<Option<T>>) this.getClass());
         if (renderer == null) {
-            System.err.println("Renderer not found for class: " + this.getClass().getName());
+            DynamicHUD.logger.error("Renderer not found for class: {}", this.getClass().getName());
             throw new RuntimeException();
         }
     }
 
-    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
         this.x = x;
         this.y = y;
 
@@ -65,30 +66,41 @@ public abstract class Option<T> {
     }
 
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        return isMouseOver(mouseX, mouseY) || renderer.mouseClicked(this,mouseX,mouseY,button);
-
+        return isMouseOver(mouseX, mouseY) || renderer.mouseClicked(this, mouseX, mouseY, button);
     }
 
     public boolean mouseReleased(double mouseX, double mouseY, int button) {
-        return isMouseOver(mouseX, mouseY) || renderer.mouseReleased(this,mouseX,mouseY,button);
+        return isMouseOver(mouseX, mouseY) || renderer.mouseReleased(this, mouseX, mouseY, button);
     }
 
-    public boolean mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
-        return isMouseOver(mouseX, mouseY) || renderer.mouseDragged(this,mouseX,mouseY,button,deltaX,deltaY);
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        return isMouseOver(mouseX, mouseY) || renderer.mouseDragged(this, mouseX, mouseY, button, deltaX, deltaY);
     }
 
-    public void keyPressed(int key) {
-         renderer.keyPressed(this,key);
-    }
-    public void keyReleased(int key) {
-         renderer.keyReleased(this,key);
-    }
     public void mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-        renderer.mouseScrolled(this,mouseX,mouseY,horizontalAmount,verticalAmount);
+        renderer.mouseScrolled(this, mouseX, mouseY, horizontalAmount, verticalAmount);
     }
 
-    //Called when the context menu closes
-    public void onClose(){}
+    @Override
+    public void keyPressed(int key, int scanCode, int modifiers) {
+        renderer.keyPressed(this, key, scanCode, modifiers);
+    }
+
+    @Override
+    public void charTyped(char c) {
+
+    }
+
+    @Override
+    public void keyReleased(int key, int scanCode, int modifiers) {
+        renderer.keyReleased(this, key, scanCode, modifiers);
+    }
+
+    /**
+     * Called when the context menu closes
+     */
+    public void onClose() {
+    }
 
     public boolean isMouseOver(double mouseX, double mouseY) {
         return mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height;
@@ -107,38 +119,39 @@ public abstract class Option<T> {
         return properties;
     }
 
-    public void setY(int y) {
-        this.y = y;
-    }
-
-    public void setX(int x) {
-        this.x = x;
-    }
-
-    public void setWidth(int width) {
-        this.width = width;
-    }
-
-    public void setHeight(int height) {
-        this.height = height;
-    }
-
     public int getY() {
         return y;
+    }
+
+    public void setY(int y) {
+        this.y = y;
     }
 
     public int getX() {
         return x;
     }
 
+    public void setX(int x) {
+        this.x = x;
+    }
+
     public int getHeight() {
         return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
     }
 
     public int getWidth() {
         return width;
     }
-    public void set(int x, int y){
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public void set(int x, int y) {
         this.x = x;
         this.y = y;
     }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/Option.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/Option.java
@@ -1,5 +1,6 @@
 package com.tanishisherewith.dynamichud.utils.contextmenu;
 
+import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.SkinRenderer;
 import com.tanishisherewith.dynamichud.widget.Widget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
@@ -18,58 +19,77 @@ public abstract class Option<T> {
     protected Consumer<T> setter;
     protected T defaultValue = null;
     protected MinecraftClient mc = MinecraftClient.getInstance();
+    protected ContextMenuProperties properties;
+    protected SkinRenderer<Option<T>> renderer;
 
     public Option(Supplier<T> getter, Consumer<T> setter) {
-        this.getter = getter;
-        this.setter = setter;
-        value = get();
-        defaultValue = get();
+        this(getter,setter,()->true);
     }
 
-    public Option(Supplier<T> getter, Consumer<T> setter, Supplier<Boolean> shouldRender) {
+    public Option(Supplier<T> getter, Consumer<T> setter, Supplier<Boolean> shouldRender,ContextMenuProperties properties) {
         this.getter = getter;
         this.setter = setter;
         this.shouldRender = shouldRender;
         value = get();
         defaultValue = get();
+        updateProperties(properties);
     }
 
-    protected T get() {
+    public Option(Supplier<T> getter, Consumer<T> setter, Supplier<Boolean> shouldRender) {
+       this(getter,setter,shouldRender,ContextMenuProperties.createGenericSimplified());
+    }
+
+    public T get() {
         return getter.get();
     }
 
-    protected void set(T value) {
+    public void set(T value) {
         this.value = value;
         setter.accept(value);
     }
 
-    public void render(DrawContext drawContext, int x, int y) {
+    public void updateProperties(ContextMenuProperties properties){
+        this.properties = properties;
+        this.renderer = properties.getSkin().getRenderer((Class<Option<T>>) this.getClass());
+        if (renderer == null) {
+            System.err.println("Renderer not found for class: " + this.getClass().getName());
+            throw new RuntimeException();
+        }
+    }
+
+    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
         this.x = x;
         this.y = y;
-    }
-    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
-        this.render(drawContext, x, y);
+
+        // Retrieve the renderer and ensure it is not null
+        renderer.render(drawContext, this, x, y, mouseX, mouseY);
     }
 
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        return isMouseOver(mouseX, mouseY);
+        return isMouseOver(mouseX, mouseY) || renderer.mouseClicked(this,mouseX,mouseY,button);
+
     }
 
     public boolean mouseReleased(double mouseX, double mouseY, int button) {
-        return isMouseOver(mouseX, mouseY);
+        return isMouseOver(mouseX, mouseY) || renderer.mouseReleased(this,mouseX,mouseY,button);
     }
 
-    public boolean mouseDragged(double mouseX, double mouseY, int button) {
-        return isMouseOver(mouseX, mouseY);
+    public boolean mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
+        return isMouseOver(mouseX, mouseY) || renderer.mouseDragged(this,mouseX,mouseY,button,deltaX,deltaY);
     }
 
     public void keyPressed(int key) {
-
+         renderer.keyPressed(this,key);
     }
-
     public void keyReleased(int key) {
-
+         renderer.keyReleased(this,key);
     }
+    public void mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+        renderer.mouseScrolled(this,mouseX,mouseY,horizontalAmount,verticalAmount);
+    }
+
+    //Called when the context menu closes
+    public void onClose(){}
 
     public boolean isMouseOver(double mouseX, double mouseY) {
         return mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height;
@@ -82,5 +102,9 @@ public abstract class Option<T> {
 
     public boolean shouldRender() {
         return shouldRender.get();
+    }
+
+    public ContextMenuProperties getProperties() {
+        return properties;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/ContextMenuScreen.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/ContextMenuScreen.java
@@ -1,0 +1,87 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen;
+
+import com.tanishisherewith.dynamichud.helpers.DrawHelper;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProperties;
+import com.tanishisherewith.dynamichud.widget.WidgetRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.text.Text;
+
+public class ContextMenuScreen extends Screen {
+    ContextMenu contextMenu;
+    ContextMenuProperties properties;
+
+    protected ContextMenuScreen(ContextMenu menu,ContextMenuProperties properties) {
+        super(Text.of("ContextMenu screen"));
+        this.contextMenu = menu;
+        this.properties = properties;
+    }
+
+    @Override
+    public void onDisplayed() {
+        super.onDisplayed();
+        contextMenu.shouldDisplay = true;
+    }
+
+    @Override
+    public void render(DrawContext drawContext, int mouseX, int mouseY, float delta) {
+        contextMenu.update();
+        DrawHelper.scaleAndPosition(drawContext.getMatrices(), (float) width /2, (float) height /2,contextMenu.scale);
+
+        properties.getSkin().setContextMenu(contextMenu);
+        properties.getSkin().renderContextMenu(drawContext,contextMenu,mouseX,mouseY);
+
+        DrawHelper.stopScaling(drawContext.getMatrices());
+
+        if(contextMenu.scale <= 0 && !contextMenu.shouldDisplay){
+            contextMenu.close();
+        }
+    }
+
+    @Override
+    protected void renderDarkening(DrawContext context) {
+
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        contextMenu.mouseClicked(mouseX,mouseY,button);
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        contextMenu.mouseDragged(mouseX,mouseY,button,deltaX,deltaY);
+        return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+        contextMenu.mouseScrolled(mouseX,mouseY,horizontalAmount,verticalAmount);
+        return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
+    }
+
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        contextMenu.mouseReleased(mouseX,mouseY,button);
+        return super.mouseReleased(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
+        contextMenu.keyReleased(keyCode,scanCode,modifiers);
+        return super.keyReleased(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        contextMenu.keyPressed(keyCode,scanCode,modifiers);
+        return super.keyPressed(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public void close() {
+        contextMenu.close();
+    }
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/ContextMenuScreen.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/ContextMenuScreen.java
@@ -3,7 +3,6 @@ package com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen;
 import com.tanishisherewith.dynamichud.helpers.DrawHelper;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProperties;
-import com.tanishisherewith.dynamichud.widget.WidgetRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Text;
@@ -12,7 +11,7 @@ public class ContextMenuScreen extends Screen {
     ContextMenu contextMenu;
     ContextMenuProperties properties;
 
-    protected ContextMenuScreen(ContextMenu menu,ContextMenuProperties properties) {
+    protected ContextMenuScreen(ContextMenu menu, ContextMenuProperties properties) {
         super(Text.of("ContextMenu screen"));
         this.contextMenu = menu;
         this.properties = properties;
@@ -27,14 +26,14 @@ public class ContextMenuScreen extends Screen {
     @Override
     public void render(DrawContext drawContext, int mouseX, int mouseY, float delta) {
         contextMenu.update();
-        DrawHelper.scaleAndPosition(drawContext.getMatrices(), (float) width /2, (float) height /2,contextMenu.getScale());
+        DrawHelper.scaleAndPosition(drawContext.getMatrices(), (float) width / 2, (float) height / 2, contextMenu.getScale());
 
         properties.getSkin().setContextMenu(contextMenu);
-        properties.getSkin().renderContextMenu(drawContext,contextMenu,mouseX,mouseY);
+        properties.getSkin().renderContextMenu(drawContext, contextMenu, mouseX, mouseY);
 
         DrawHelper.stopScaling(drawContext.getMatrices());
 
-        if(contextMenu.getScale() <= 0 && !contextMenu.isVisible()){
+        if (contextMenu.getScale() <= 0 && !contextMenu.isVisible()) {
             contextMenu.close();
         }
     }
@@ -46,37 +45,37 @@ public class ContextMenuScreen extends Screen {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        contextMenu.mouseClicked(mouseX,mouseY,button);
+        contextMenu.mouseClicked(mouseX, mouseY, button);
         return super.mouseClicked(mouseX, mouseY, button);
     }
 
     @Override
     public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
-        contextMenu.mouseDragged(mouseX,mouseY,button,deltaX,deltaY);
+        contextMenu.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
         return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
     }
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-        contextMenu.mouseScrolled(mouseX,mouseY,horizontalAmount,verticalAmount);
+        contextMenu.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
         return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
     }
 
     @Override
     public boolean mouseReleased(double mouseX, double mouseY, int button) {
-        contextMenu.mouseReleased(mouseX,mouseY,button);
+        contextMenu.mouseReleased(mouseX, mouseY, button);
         return super.mouseReleased(mouseX, mouseY, button);
     }
 
     @Override
     public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
-        contextMenu.keyReleased(keyCode,scanCode,modifiers);
+        contextMenu.keyReleased(keyCode, scanCode, modifiers);
         return super.keyReleased(keyCode, scanCode, modifiers);
     }
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        contextMenu.keyPressed(keyCode,scanCode,modifiers);
+        contextMenu.keyPressed(keyCode, scanCode, modifiers);
         return super.keyPressed(keyCode, scanCode, modifiers);
     }
 

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/ContextMenuScreen.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/ContextMenuScreen.java
@@ -21,20 +21,20 @@ public class ContextMenuScreen extends Screen {
     @Override
     public void onDisplayed() {
         super.onDisplayed();
-        contextMenu.shouldDisplay = true;
+        contextMenu.setVisible(true);
     }
 
     @Override
     public void render(DrawContext drawContext, int mouseX, int mouseY, float delta) {
         contextMenu.update();
-        DrawHelper.scaleAndPosition(drawContext.getMatrices(), (float) width /2, (float) height /2,contextMenu.scale);
+        DrawHelper.scaleAndPosition(drawContext.getMatrices(), (float) width /2, (float) height /2,contextMenu.getScale());
 
         properties.getSkin().setContextMenu(contextMenu);
         properties.getSkin().renderContextMenu(drawContext,contextMenu,mouseX,mouseY);
 
         DrawHelper.stopScaling(drawContext.getMatrices());
 
-        if(contextMenu.scale <= 0 && !contextMenu.shouldDisplay){
+        if(contextMenu.getScale() <= 0 && !contextMenu.isVisible()){
             contextMenu.close();
         }
     }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/ContextMenuScreenFactory.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/ContextMenuScreenFactory.java
@@ -1,0 +1,14 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen;
+
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProperties;
+import net.minecraft.client.gui.screen.Screen;
+
+/**
+ * We will use this interface to provide the context menu with the screen required by its skins.
+ * Some skins like {@link com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.MinecraftSkin} require a separate screen to render its contents.
+ * This can also be used for developers to provide a new custom screen by them or for a custom skin.
+ */
+public interface ContextMenuScreenFactory {
+    Screen create(ContextMenu contextMenu, ContextMenuProperties properties);
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/DefaultContextMenuScreenFactory.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/contextmenuscreen/DefaultContextMenuScreenFactory.java
@@ -1,0 +1,15 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen;
+
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProperties;
+import net.minecraft.client.gui.screen.Screen;
+
+/**
+ * Default implementation of the {@link ContextMenuScreenFactory} providing a {@link ContextMenuScreen}
+ */
+public class DefaultContextMenuScreenFactory implements ContextMenuScreenFactory {
+    @Override
+    public Screen create(ContextMenu contextMenu, ContextMenuProperties properties) {
+        return new ContextMenuScreen(contextMenu, properties);
+    }
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/BooleanOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/BooleanOption.java
@@ -13,7 +13,7 @@ import java.util.function.Supplier;
 
 public class BooleanOption extends Option<Boolean> {
     public String name = "Empty";
-    private BooleanType booleanType;
+    private final BooleanType booleanType;
 
     public BooleanOption(String name, Supplier<Boolean> getter, Consumer<Boolean> setter, BooleanType booleanType) {
         super(getter, setter);
@@ -21,25 +21,26 @@ public class BooleanOption extends Option<Boolean> {
         this.booleanType = booleanType;
         this.renderer.init(this);
     }
+
     public BooleanOption(String name, Supplier<Boolean> getter, Consumer<Boolean> setter) {
-        this(name,getter,setter,BooleanType.TRUE_FALSE);
+        this(name, getter, setter, BooleanType.TRUE_FALSE);
     }
 
     public BooleanOption(String name, boolean defaultValue) {
-        this(name,defaultValue,BooleanType.TRUE_FALSE);
+        this(name, defaultValue, BooleanType.TRUE_FALSE);
     }
 
-    public BooleanOption(String name, boolean defaultValue,BooleanType type) {
-        this(name, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value),type);
+    public BooleanOption(String name, boolean defaultValue, BooleanType type) {
+        this(name, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value), type);
         BooleanPool.put(name, defaultValue);
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
         value = get();
-        super.render(drawContext, x, y,mouseX,mouseY);
+        super.render(drawContext, x, y, mouseX, mouseY);
 
-      //  properties.getSkin().getRenderer(BooleanOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+        //  properties.getSkin().getRenderer(BooleanOption.class).render(drawContext,this,x,y,mouseX,mouseY);
         /*
         int color = value ? Color.GREEN.getRGB() : Color.RED.getRGB();
         drawContext.drawText(mc.textRenderer, Text.of(name), x, y, color, false);
@@ -56,25 +57,25 @@ public class BooleanOption extends Option<Boolean> {
             set(value);
             return true;
         }
-        return super.mouseClicked(mouseX,mouseY,button);
+        return super.mouseClicked(mouseX, mouseY, button);
     }
 
     public BooleanType getBooleanType() {
         return booleanType;
     }
 
-    public enum BooleanType{
+    public enum BooleanType {
         ON_OFF(ScreenTexts::onOrOff),
         TRUE_FALSE(aBoolean -> aBoolean ? Text.of("True") : Text.of("False")),
-        YES_NO(aBoolean -> aBoolean ? ScreenTexts.YES: ScreenTexts.NO);
+        YES_NO(aBoolean -> aBoolean ? ScreenTexts.YES : ScreenTexts.NO);
 
-        private final Function<Boolean,Text> function;
+        private final Function<Boolean, Text> function;
 
-        BooleanType(Function<Boolean, Text> function){
+        BooleanType(Function<Boolean, Text> function) {
             this.function = function;
         }
 
-        public Text getText(boolean val){
+        public Text getText(boolean val) {
             return function.apply(val);
         }
     }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/BooleanOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/BooleanOption.java
@@ -3,43 +3,79 @@ package com.tanishisherewith.dynamichud.utils.contextmenu.options;
 import com.tanishisherewith.dynamichud.utils.BooleanPool;
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.screen.ScreenTexts;
 import net.minecraft.text.Text;
+import org.lwjgl.glfw.GLFW;
 
-import java.awt.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class BooleanOption extends Option<Boolean> {
     public String name = "Empty";
+    private BooleanType booleanType;
 
-    public BooleanOption(String name, Supplier<Boolean> getter, Consumer<Boolean> setter) {
+    public BooleanOption(String name, Supplier<Boolean> getter, Consumer<Boolean> setter, BooleanType booleanType) {
         super(getter, setter);
         this.name = name;
+        this.booleanType = booleanType;
+        this.renderer.init(this);
+    }
+    public BooleanOption(String name, Supplier<Boolean> getter, Consumer<Boolean> setter) {
+        this(name,getter,setter,BooleanType.TRUE_FALSE);
     }
 
     public BooleanOption(String name, boolean defaultValue) {
-        this(name, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value));
+        this(name,defaultValue,BooleanType.TRUE_FALSE);
+    }
+
+    public BooleanOption(String name, boolean defaultValue,BooleanType type) {
+        this(name, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value),type);
         BooleanPool.put(name, defaultValue);
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y) {
-        super.render(drawContext, x, y);
-
+    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
         value = get();
+        super.render(drawContext, x, y,mouseX,mouseY);
+
+      //  properties.getSkin().getRenderer(BooleanOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+        /*
         int color = value ? Color.GREEN.getRGB() : Color.RED.getRGB();
         drawContext.drawText(mc.textRenderer, Text.of(name), x, y, color, false);
         this.height = mc.textRenderer.fontHeight;
         this.width = mc.textRenderer.getWidth(name) + 1;
+
+         */
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        if (isMouseOver(mouseX, mouseY)) {
+        if (isMouseOver(mouseX, mouseY) && button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
             value = !value;
             set(value);
+            return true;
         }
-        return true;
+        return super.mouseClicked(mouseX,mouseY,button);
+    }
+
+    public BooleanType getBooleanType() {
+        return booleanType;
+    }
+
+    public enum BooleanType{
+        ON_OFF(ScreenTexts::onOrOff),
+        TRUE_FALSE(aBoolean -> aBoolean ? Text.of("True") : Text.of("False")),
+        YES_NO(aBoolean -> aBoolean ? ScreenTexts.YES: ScreenTexts.NO);
+
+        private final Function<Boolean,Text> function;
+
+        BooleanType(Function<Boolean, Text> function){
+            this.function = function;
+        }
+
+        public Text getText(boolean val){
+            return function.apply(val);
+        }
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ColorOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ColorOption.java
@@ -22,12 +22,16 @@ public class ColorOption extends Option<Color> {
         this.name = name;
         this.parentMenu = parentMenu;
         colorPicker = new ColorGradientPicker(x + this.parentMenu.finalWidth, y - 10, get(), this::set, 50, 100);
+        this.renderer.init(this);
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y) {
-        super.render(drawContext, x, y);
+    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
+        super.render(drawContext, x, y,mouseX,mouseY);
 
+     //   properties.getSkin().getRenderer(ColorOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+
+        /*
         int color = isVisible ? Color.GREEN.getRGB() : Color.RED.getRGB();
         this.height = mc.textRenderer.fontHeight;
         this.width = mc.textRenderer.getWidth(name) + 8;
@@ -46,6 +50,8 @@ public class ColorOption extends Option<Color> {
                 1);
 
         colorPicker.render(drawContext, this.x + parentMenu.finalWidth + 7, y - 10);
+
+         */
     }
 
     @Override
@@ -70,8 +76,18 @@ public class ColorOption extends Option<Color> {
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button) {
+    public boolean mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
         colorPicker.mouseDragged(mouseX, mouseY, button);
-        return super.mouseDragged(mouseX, mouseY, button);
+        return super.mouseDragged(mouseX, mouseY, button,deltaX,deltaY);
+    }
+
+    public ColorGradientPicker getColorPicker() {
+        return colorPicker;
+    }
+
+    @Override
+    public void onClose() {
+        isVisible = false;
+        colorPicker.close();
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ColorOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ColorOption.java
@@ -1,11 +1,9 @@
 package com.tanishisherewith.dynamichud.utils.contextmenu.options;
 
-import com.tanishisherewith.dynamichud.helpers.DrawHelper;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import com.tanishisherewith.dynamichud.utils.contextmenu.options.coloroption.ColorGradientPicker;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.text.Text;
 
 import java.awt.*;
 import java.util.function.Consumer;
@@ -26,10 +24,10 @@ public class ColorOption extends Option<Color> {
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
-        super.render(drawContext, x, y,mouseX,mouseY);
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
+        super.render(drawContext, x, y, mouseX, mouseY);
 
-     //   properties.getSkin().getRenderer(ColorOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+        //   properties.getSkin().getRenderer(ColorOption.class).render(drawContext,this,x,y,mouseX,mouseY);
 
         /*
         int color = isVisible ? Color.GREEN.getRGB() : Color.RED.getRGB();
@@ -76,9 +74,9 @@ public class ColorOption extends Option<Color> {
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
         colorPicker.mouseDragged(mouseX, mouseY, button);
-        return super.mouseDragged(mouseX, mouseY, button,deltaX,deltaY);
+        return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
     }
 
     public ColorGradientPicker getColorPicker() {

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ColorOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ColorOption.java
@@ -21,7 +21,7 @@ public class ColorOption extends Option<Color> {
         super(getter, setter);
         this.name = name;
         this.parentMenu = parentMenu;
-        colorPicker = new ColorGradientPicker(x + this.parentMenu.finalWidth, y - 10, get(), this::set, 50, 100);
+        colorPicker = new ColorGradientPicker(x + this.parentMenu.getFinalWidth(), y - 10, get(), this::set, 50, 100);
         this.renderer.init(this);
     }
 
@@ -59,7 +59,7 @@ public class ColorOption extends Option<Color> {
         if (isMouseOver(mouseX, mouseY)) {
             isVisible = !isVisible;
             if (isVisible) {
-                colorPicker.setPos(this.x + parentMenu.finalWidth + 7, y - 10);
+                colorPicker.setPos(this.x + parentMenu.getFinalWidth() + 7, y - 10);
                 colorPicker.display();
             } else {
                 colorPicker.close();

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/DoubleOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/DoubleOption.java
@@ -3,7 +3,6 @@ package com.tanishisherewith.dynamichud.utils.contextmenu.options;
 import com.tanishisherewith.dynamichud.helpers.DrawHelper;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
-import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import org.apache.commons.lang3.Validate;
 import org.lwjgl.glfw.GLFW;
@@ -14,11 +13,11 @@ import java.util.function.Supplier;
 
 public class DoubleOption extends Option<Double> {
     public String name = "Empty";
-    float step = 0.1f;
-    private boolean isDragging = false;
     public double minValue = 0.0;
     public double maxValue = 0.0;
+    float step = 0.1f;
     ContextMenu parentMenu;
+    private boolean isDragging = false;
 
     public DoubleOption(String name, double minValue, double maxValue, float step, Supplier<Double> getter, Consumer<Double> setter, ContextMenu parentMenu) {
         super(getter, setter);
@@ -35,9 +34,9 @@ public class DoubleOption extends Option<Double> {
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
         value = get();
-        super.render(drawContext, x, y,mouseX,mouseY);
+        super.render(drawContext, x, y, mouseX, mouseY);
 
         //properties.getSkin().getRenderer(DoubleOption.class).render(drawContext,this,x,y,mouseX,mouseY);
 
@@ -108,10 +107,10 @@ public class DoubleOption extends Option<Double> {
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
         if (isMouseOver(mouseX, mouseY) && isDragging) {
             step(mouseX);
         }
-        return super.mouseDragged(mouseX, mouseY, button,deltaX,deltaY);
+        return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/DoubleOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/DoubleOption.java
@@ -6,6 +6,7 @@ import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import org.apache.commons.lang3.Validate;
+import org.lwjgl.glfw.GLFW;
 
 import java.awt.*;
 import java.util.function.Consumer;
@@ -15,7 +16,8 @@ public class DoubleOption extends Option<Double> {
     public String name = "Empty";
     float step = 0.1f;
     private boolean isDragging = false;
-    private double minValue = 0.0, maxValue = 0.0;
+    public double minValue = 0.0;
+    public double maxValue = 0.0;
     ContextMenu parentMenu;
 
     public DoubleOption(String name, double minValue, double maxValue, float step, Supplier<Double> getter, Consumer<Double> setter, ContextMenu parentMenu) {
@@ -29,13 +31,17 @@ public class DoubleOption extends Option<Double> {
         this.step = step;
         this.parentMenu = parentMenu;
         Validate.isTrue(this.step > 0.0f, "Step cannot be less than or equal to 0 (zero)");
+        this.renderer.init(this);
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y) {
-        super.render(drawContext, x, y);
+    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
         value = get();
+        super.render(drawContext, x, y,mouseX,mouseY);
 
+        //properties.getSkin().getRenderer(DoubleOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+
+        /*
         this.width = 35;
         this.height = 16;
 
@@ -68,9 +74,11 @@ public class DoubleOption extends Option<Double> {
                 90,
                 0.6f,
                 0.6f);
+
+         */
     }
 
-    private void drawSlider(DrawContext drawContext, int sliderX, int sliderY, int sliderWidth, double handleX) {
+    public void drawSlider(DrawContext drawContext, int sliderX, int sliderY, int sliderWidth, double handleX) {
         DrawHelper.drawRectangle(drawContext.getMatrices().peek().getPositionMatrix(), sliderX, sliderY, sliderWidth, 2, 0xFFFFFFFF);
         if (handleX - sliderX > 0) {
             DrawHelper.drawRectangle(drawContext.getMatrices().peek().getPositionMatrix(), (float) sliderX, (float) sliderY, (float) ((value - minValue) / (maxValue - minValue) * (width - 3)), 2, Color.ORANGE.getRGB());
@@ -79,8 +87,7 @@ public class DoubleOption extends Option<Double> {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        if (isMouseOver(mouseX, mouseY)) {
+        if (super.mouseClicked(mouseX, mouseY, button) && button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
             step(mouseX);
             isDragging = true;
         }
@@ -93,7 +100,7 @@ public class DoubleOption extends Option<Double> {
         return super.mouseReleased(mouseX, mouseY, button);
     }
 
-    private void step(double mouseX) {
+    public void step(double mouseX) {
         double newValue = minValue + (float) (mouseX - x) / width * (maxValue - minValue);
         // Round the new value to the nearest step
         newValue = Math.round(newValue / step) * step;
@@ -101,10 +108,10 @@ public class DoubleOption extends Option<Double> {
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button) {
+    public boolean mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
         if (isMouseOver(mouseX, mouseY) && isDragging) {
             step(mouseX);
         }
-        return super.mouseDragged(mouseX, mouseY, button);
+        return super.mouseDragged(mouseX, mouseY, button,deltaX,deltaY);
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/EnumOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/EnumOption.java
@@ -24,24 +24,29 @@ public class EnumOption<E extends Enum<E>> extends Option<E> {
                 break;
             }
         }
+        this.renderer.init(this);
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y) {
-        super.render(drawContext, x, y);
-
+    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
         value = get();
+        super.render(drawContext, x, y,mouseX,mouseY);
+
+        //  properties.getSkin().getRenderer(EnumOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+
+        /*
         this.height = mc.textRenderer.fontHeight + 1;
         this.width = mc.textRenderer.getWidth(name + ": " + value.name()) + 1;
 
         drawContext.drawText(mc.textRenderer, Text.of(name + ": "), x, y, Color.WHITE.getRGB(), false);
         drawContext.drawText(mc.textRenderer, Text.of(value.name()), x + mc.textRenderer.getWidth(name + ": ") + 1, y, Color.CYAN.getRGB(), false);
+
+         */
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        if (isMouseOver(mouseX, mouseY)) {
+        if (super.mouseClicked(mouseX,mouseY,button)) {
             if (button == 0) {
                 currentIndex = (currentIndex + 1) % values.length;
                 if (currentIndex > values.length - 1) {
@@ -58,5 +63,9 @@ public class EnumOption<E extends Enum<E>> extends Option<E> {
             set(value);
         }
         return true;
+    }
+
+    public E[] getValues() {
+        return values;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/EnumOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/EnumOption.java
@@ -2,9 +2,7 @@ package com.tanishisherewith.dynamichud.utils.contextmenu.options;
 
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.text.Text;
 
-import java.awt.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -28,9 +26,9 @@ public class EnumOption<E extends Enum<E>> extends Option<E> {
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
         value = get();
-        super.render(drawContext, x, y,mouseX,mouseY);
+        super.render(drawContext, x, y, mouseX, mouseY);
 
         //  properties.getSkin().getRenderer(EnumOption.class).render(drawContext,this,x,y,mouseX,mouseY);
 
@@ -46,7 +44,7 @@ public class EnumOption<E extends Enum<E>> extends Option<E> {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (super.mouseClicked(mouseX,mouseY,button)) {
+        if (super.mouseClicked(mouseX, mouseY, button)) {
             if (button == 0) {
                 currentIndex = (currentIndex + 1) % values.length;
                 if (currentIndex > values.length - 1) {

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ListOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ListOption.java
@@ -25,25 +25,27 @@ public class ListOption<T> extends Option<T> {
                 break;
             }
         }
+        this.renderer.init(this);
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y) {
-        super.render(drawContext, x, y);
-
+    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
         value = get();
+        super.render(drawContext, x, y,mouseX,mouseY);
+
+        // properties.getSkin().getRenderer(ListOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+/*
         this.height = mc.textRenderer.fontHeight + 1;
         this.width = mc.textRenderer.getWidth(name + ": " + value.toString()) + 1;
 
         drawContext.drawText(mc.textRenderer, Text.of(name + ": "), x, y, Color.WHITE.getRGB(), false);
         drawContext.drawText(mc.textRenderer, Text.of(value.toString()), x + mc.textRenderer.getWidth(name + ": ") + 1, y, Color.CYAN.getRGB(), false);
-
+*/
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        if (isMouseOver(mouseX, mouseY)) {
+        if (super.mouseClicked(mouseX, mouseY, button)) {
             if (button == 0) {
                 currentIndex = (currentIndex + 1) % values.size();
                 if (currentIndex > values.size() - 1) {
@@ -60,5 +62,9 @@ public class ListOption<T> extends Option<T> {
             set(value);
         }
         return true;
+    }
+
+    public List<T> getValues() {
+        return values;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ListOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/ListOption.java
@@ -2,9 +2,7 @@ package com.tanishisherewith.dynamichud.utils.contextmenu.options;
 
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.text.Text;
 
-import java.awt.*;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -29,9 +27,9 @@ public class ListOption<T> extends Option<T> {
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
         value = get();
-        super.render(drawContext, x, y,mouseX,mouseY);
+        super.render(drawContext, x, y, mouseX, mouseY);
 
         // properties.getSkin().getRenderer(ListOption.class).render(drawContext,this,x,y,mouseX,mouseY);
 /*

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/RunnableOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/RunnableOption.java
@@ -25,6 +25,7 @@ public class RunnableOption extends Option<Boolean> {
         super(getter, setter);
         this.name = "Run: " + name; // prepend the "run" symbol to the name
         this.task = task;
+        this.renderer.init(this);
     }
 
     public RunnableOption(String name, boolean defaultValue,Runnable task) {
@@ -32,24 +33,25 @@ public class RunnableOption extends Option<Boolean> {
         BooleanPool.put(name, defaultValue);
     }
 
-    Color DARK_RED = new Color(116, 0, 0);
-    Color DARK_GREEN = new Color(24, 132, 0, 226);
-
     @Override
-    public void render(DrawContext drawContext, int x, int y) {
-        super.render(drawContext, x, y);
-
+    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
         value = get();
+        super.render(drawContext, x, y,mouseX,mouseY);
+
+        //properties.getSkin().getRenderer(RunnableOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+
+        /*
         this.height = mc.textRenderer.fontHeight;
         this.width = mc.textRenderer.getWidth("Run: " + name);
         int color = value ? DARK_GREEN.getRGB() : DARK_RED.getRGB();
         drawContext.drawText(mc.textRenderer, Text.of(name), x, y, color, false);
+
+         */
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        if (isMouseOver(mouseX, mouseY)) {
+        if (super.mouseClicked(mouseX, mouseY, button)) {
             value = !value;
             set(value);
             if (value) {

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/RunnableOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/RunnableOption.java
@@ -3,9 +3,7 @@ package com.tanishisherewith.dynamichud.utils.contextmenu.options;
 import com.tanishisherewith.dynamichud.utils.BooleanPool;
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.text.Text;
 
-import java.awt.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -28,15 +26,15 @@ public class RunnableOption extends Option<Boolean> {
         this.renderer.init(this);
     }
 
-    public RunnableOption(String name, boolean defaultValue,Runnable task) {
-        this(name, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value),task);
+    public RunnableOption(String name, boolean defaultValue, Runnable task) {
+        this(name, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value), task);
         BooleanPool.put(name, defaultValue);
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y,int mouseX, int mouseY) {
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
         value = get();
-        super.render(drawContext, x, y,mouseX,mouseY);
+        super.render(drawContext, x, y, mouseX, mouseY);
 
         //properties.getSkin().getRenderer(RunnableOption.class).render(drawContext,this,x,y,mouseX,mouseY);
 

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/SubMenuOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/SubMenuOption.java
@@ -2,12 +2,14 @@ package com.tanishisherewith.dynamichud.utils.contextmenu.options;
 
 import com.tanishisherewith.dynamichud.utils.BooleanPool;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProperties;
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.Text;
 
 import java.awt.*;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -23,31 +25,30 @@ public class SubMenuOption extends Option<Boolean> {
     private final ContextMenu parentMenu;
     public String name = "Empty";
 
-
-    public SubMenuOption(String name, ContextMenu parentMenu, Supplier<Boolean> getter, Consumer<Boolean> setter) {
+    public SubMenuOption(String name, ContextMenu parentMenu, Supplier<Boolean> getter, Consumer<Boolean> setter, ContextMenuProperties properties) {
         super(getter, setter);
         Objects.requireNonNull(parentMenu, "Parent Menu cannot be null");
         this.name = name;
         this.parentMenu = parentMenu;
-        this.subMenu = new ContextMenu(parentMenu.x + parentMenu.finalWidth, this.y);
-        this.subMenu.heightOffset = 0;
+        this.subMenu = new ContextMenu(parentMenu.x + parentMenu.finalWidth, this.y,properties);
+        this.subMenu.getProperties().setHeightOffset(0);
         this.subMenu.shouldDisplay = get();
+        this.renderer.init(this);
+    }
+    public SubMenuOption(String name, ContextMenu parentMenu, ContextMenuProperties properties) {
+        this(name, parentMenu, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value),properties);
+    }
+    public SubMenuOption(String name, ContextMenu parentMenu, Supplier<Boolean> getter, Consumer<Boolean> setter) {
+        this(name,parentMenu,getter,setter,parentMenu.getProperties().copy());
     }
     public SubMenuOption(String name, ContextMenu parentMenu) {
-        this(name, parentMenu, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value));
+        this(name, parentMenu, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value),parentMenu.getProperties().copy());
     }
 
     @Override
     public void render(DrawContext drawContext, int x, int y,int mouseX,int mouseY) {
-        this.x = x;
-        this.y = y;
-
-        int color = value ? Color.GREEN.getRGB() : Color.RED.getRGB();
-        drawContext.drawText(mc.textRenderer, Text.of(name), x, y + 1, color, false);
-        this.height = mc.textRenderer.fontHeight + 2;
-        this.width = mc.textRenderer.getWidth(name) + 1;
-
-        subMenu.render(drawContext, this.x + parentMenu.finalWidth, this.y, 0,mouseX, mouseY);
+        super.render(drawContext,x,y,mouseX,mouseY);
+      //  properties.getSkin().getRenderer(SubMenuOption.class).render(drawContext,this,x,y,mouseX,mouseY);
     }
 
     @Override
@@ -68,9 +69,9 @@ public class SubMenuOption extends Option<Boolean> {
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button) {
-        subMenu.mouseDragged(mouseX, mouseY, button);
-        return super.mouseDragged(mouseX, mouseY, button);
+    public boolean mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
+        subMenu.mouseDragged(mouseX, mouseY, button,deltaX, deltaY);
+        return super.mouseDragged(mouseX, mouseY, button,deltaX, deltaY);
     }
 
     public SubMenuOption getOption() {
@@ -79,5 +80,9 @@ public class SubMenuOption extends Option<Boolean> {
 
     public ContextMenu getSubMenu() {
         return subMenu;
+    }
+
+    public ContextMenu getParentMenu() {
+        return parentMenu;
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/SubMenuOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/SubMenuOption.java
@@ -5,11 +5,8 @@ import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProperties;
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.text.Text;
 
-import java.awt.*;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -30,25 +27,28 @@ public class SubMenuOption extends Option<Boolean> {
         Objects.requireNonNull(parentMenu, "Parent Menu cannot be null");
         this.name = name;
         this.parentMenu = parentMenu;
-        this.subMenu = new ContextMenu(parentMenu.x + parentMenu.getFinalWidth(), this.y,properties);
+        this.subMenu = new ContextMenu(parentMenu.x + parentMenu.getFinalWidth(), this.y, properties);
         this.subMenu.getProperties().setHeightOffset(0);
         this.subMenu.setVisible(get());
         this.renderer.init(this);
     }
+
     public SubMenuOption(String name, ContextMenu parentMenu, ContextMenuProperties properties) {
-        this(name, parentMenu, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value),properties);
+        this(name, parentMenu, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value), properties);
     }
+
     public SubMenuOption(String name, ContextMenu parentMenu, Supplier<Boolean> getter, Consumer<Boolean> setter) {
-        this(name,parentMenu,getter,setter,parentMenu.getProperties().copy());
+        this(name, parentMenu, getter, setter, parentMenu.getProperties().copy());
     }
+
     public SubMenuOption(String name, ContextMenu parentMenu) {
-        this(name, parentMenu, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value),parentMenu.getProperties().copy());
+        this(name, parentMenu, () -> BooleanPool.get(name), value -> BooleanPool.put(name, value), parentMenu.getProperties().copy());
     }
 
     @Override
-    public void render(DrawContext drawContext, int x, int y,int mouseX,int mouseY) {
-        super.render(drawContext,x,y,mouseX,mouseY);
-      //  properties.getSkin().getRenderer(SubMenuOption.class).render(drawContext,this,x,y,mouseX,mouseY);
+    public void render(DrawContext drawContext, int x, int y, int mouseX, int mouseY) {
+        super.render(drawContext, x, y, mouseX, mouseY);
+        //  properties.getSkin().getRenderer(SubMenuOption.class).render(drawContext,this,x,y,mouseX,mouseY);
     }
 
     @Override
@@ -69,9 +69,9 @@ public class SubMenuOption extends Option<Boolean> {
     }
 
     @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button,double deltaX, double deltaY) {
-        subMenu.mouseDragged(mouseX, mouseY, button,deltaX, deltaY);
-        return super.mouseDragged(mouseX, mouseY, button,deltaX, deltaY);
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        subMenu.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
+        return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
     }
 
     public SubMenuOption getOption() {

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/SubMenuOption.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/SubMenuOption.java
@@ -30,9 +30,9 @@ public class SubMenuOption extends Option<Boolean> {
         Objects.requireNonNull(parentMenu, "Parent Menu cannot be null");
         this.name = name;
         this.parentMenu = parentMenu;
-        this.subMenu = new ContextMenu(parentMenu.x + parentMenu.finalWidth, this.y,properties);
+        this.subMenu = new ContextMenu(parentMenu.x + parentMenu.getFinalWidth(), this.y,properties);
         this.subMenu.getProperties().setHeightOffset(0);
-        this.subMenu.shouldDisplay = get();
+        this.subMenu.setVisible(get());
         this.renderer.init(this);
     }
     public SubMenuOption(String name, ContextMenu parentMenu, ContextMenuProperties properties) {
@@ -55,7 +55,7 @@ public class SubMenuOption extends Option<Boolean> {
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         if (super.mouseClicked(mouseX, mouseY, button)) {
             subMenu.toggleDisplay();
-            set(subMenu.shouldDisplay);
+            set(subMenu.isVisible());
             return true;
         }
         subMenu.mouseClicked(mouseX, mouseY, button);

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/coloroption/ColorGradientPicker.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/coloroption/ColorGradientPicker.java
@@ -19,9 +19,9 @@ public class ColorGradientPicker {
     private final ColorPickerButton colorPickerButton;
     private final AlphaSlider alphaSlider;
     private final int boxSize;
+    private final Color initialColor;
     private int x, y;
     private boolean display = false;
-    private final Color initialColor;
 
     public ColorGradientPicker(int x, int y, Color initialColor, Consumer<Color> onColorSelected, int boxSize, int colors) {
         this.x = x;

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/coloroption/ColorPickerButton.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/coloroption/ColorPickerButton.java
@@ -3,6 +3,8 @@ package com.tanishisherewith.dynamichud.utils.contextmenu.options.coloroption;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 
+import java.awt.*;
+
 public class ColorPickerButton {
     private final int width;
     private final int height;
@@ -23,7 +25,7 @@ public class ColorPickerButton {
         drawContext.getMatrices().push();
         drawContext.getMatrices().translate(0, 0, 404);
         // Draw the button
-        drawContext.fill(x + 2, y + 2, x + width - 2, y + height - 2, 0xFFAAAAAA);
+        drawContext.fill(x + 2, y + 2, x + width - 2, y + height - 2, isPicking() ? Color.GREEN.getRGB() :  0xFFAAAAAA);
         drawContext.drawCenteredTextWithShadow(MinecraftClient.getInstance().textRenderer, "Pick", x + width / 2, y + (height - 8) / 2, 0xFFFFFFFF);
         drawContext.getMatrices().pop();
     }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/coloroption/ColorPickerButton.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/options/coloroption/ColorPickerButton.java
@@ -25,7 +25,7 @@ public class ColorPickerButton {
         drawContext.getMatrices().push();
         drawContext.getMatrices().translate(0, 0, 404);
         // Draw the button
-        drawContext.fill(x + 2, y + 2, x + width - 2, y + height - 2, isPicking() ? Color.GREEN.getRGB() :  0xFFAAAAAA);
+        drawContext.fill(x + 2, y + 2, x + width - 2, y + height - 2, isPicking() ? Color.GREEN.getRGB() : 0xFFAAAAAA);
         drawContext.drawCenteredTextWithShadow(MinecraftClient.getInstance().textRenderer, "Pick", x + width / 2, y + (height - 8) / 2, 0xFFFFFFFF);
         drawContext.getMatrices().pop();
     }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/ClassicSkin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/ClassicSkin.java
@@ -51,7 +51,7 @@ public class ClassicSkin extends Skin {
 
             // Adjust mouse coordinates based on the scale
             if (contextMenu.getProperties().hoverEffect() && contextMenu.isMouseOver(mouseX, mouseY, contextMenu.x + 1, yOffset - 1, contextMenu.getFinalWidth() - 2, option.getHeight())) {
-                drawBackground(matrices, contextMenu, properties, yOffset - 1,contextMenu.getFinalWidth(), option.getHeight() + 1, contextMenu.getProperties().getHoverColor().getRGB(),false);
+                drawBackground(matrices, contextMenu, properties, yOffset - 1, contextMenu.getFinalWidth(), option.getHeight() + 1, contextMenu.getProperties().getHoverColor().getRGB(), false);
             }
 
             option.render(drawContext, contextMenu.x + 4, yOffset, mouseX, mouseY);
@@ -69,13 +69,13 @@ public class ClassicSkin extends Skin {
     }
 
     private void drawBackground(MatrixStack matrices, ContextMenu contextMenu, ContextMenuProperties properties) {
-        drawBackground(matrices, contextMenu, properties, contextMenu.y,contextMenu.getWidth(), contextMenu.getHeight(), properties.getBackgroundColor().getRGB(),properties.shadow());
+        drawBackground(matrices, contextMenu, properties, contextMenu.y, contextMenu.getWidth(), contextMenu.getHeight(), properties.getBackgroundColor().getRGB(), properties.shadow());
     }
 
-    private void drawBackground(MatrixStack matrices, ContextMenu contextMenu, ContextMenuProperties properties, int yOffset,int width, int height, int color,boolean shadow) {
+    private void drawBackground(MatrixStack matrices, ContextMenu contextMenu, ContextMenuProperties properties, int yOffset, int width, int height, int color, boolean shadow) {
         // Wow so good code.
         if (properties.roundedCorners()) {
-            if(shadow){
+            if (shadow) {
                 DrawHelper.drawRoundedRectangleWithShadowBadWay(matrices.peek().getPositionMatrix(),
                         contextMenu.x,
                         yOffset,
@@ -87,7 +87,7 @@ public class ClassicSkin extends Skin {
                         1,
                         1
                 );
-            }else {
+            } else {
                 DrawHelper.drawRoundedRectangle(matrices.peek().getPositionMatrix(),
                         contextMenu.x,
                         yOffset,
@@ -98,7 +98,7 @@ public class ClassicSkin extends Skin {
                 );
             }
         } else {
-            if(shadow){
+            if (shadow) {
                 DrawHelper.drawRectangleWithShadowBadWay(matrices.peek().getPositionMatrix(),
                         contextMenu.x,
                         yOffset,
@@ -109,7 +109,7 @@ public class ClassicSkin extends Skin {
                         1,
                         1
                 );
-            }else {
+            } else {
                 DrawHelper.drawRectangle(matrices.peek().getPositionMatrix(),
                         contextMenu.x,
                         yOffset,
@@ -162,7 +162,7 @@ public class ClassicSkin extends Skin {
             option.setHeight(mc.textRenderer.fontHeight);
             option.setWidth(mc.textRenderer.getWidth(option.name) + 1);
 
-            int shadowOpacity = Math.min(option.value.getAlpha(),90);
+            int shadowOpacity = Math.min(option.value.getAlpha(), 90);
             DrawHelper.drawRoundedRectangleWithShadowBadWay(drawContext.getMatrices().peek().getPositionMatrix(),
                     x + option.getWidth(),
                     y - 1,
@@ -175,6 +175,42 @@ public class ClassicSkin extends Skin {
                     1);
 
             option.getColorPicker().render(drawContext, x + option.parentMenu.getFinalWidth() + 7, y - 10);
+        }
+    }
+
+    public static class ClassicEnumRenderer<E extends Enum<E>> implements SkinRenderer<EnumOption<E>> {
+        @Override
+        public void render(DrawContext drawContext, EnumOption<E> option, int x, int y, int mouseX, int mouseY) {
+            option.setHeight(mc.textRenderer.fontHeight + 1);
+            option.setWidth(mc.textRenderer.getWidth(option.name + ": " + option.value.name()) + 1);
+
+            drawContext.drawText(mc.textRenderer, Text.of(option.name + ": "), x, y, Color.WHITE.getRGB(), false);
+            drawContext.drawText(mc.textRenderer, Text.of(option.value.name()), x + mc.textRenderer.getWidth(option.name + ": ") + 1, y, Color.CYAN.getRGB(), false);
+        }
+    }
+
+    public static class ClassicSubMenuRenderer implements SkinRenderer<SubMenuOption> {
+        @Override
+        public void render(DrawContext drawContext, SubMenuOption option, int x, int y, int mouseX, int mouseY) {
+            int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
+            drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
+            option.setHeight(mc.textRenderer.fontHeight);
+            option.setWidth(mc.textRenderer.getWidth(option.name) + 1);
+
+            option.getSubMenu().render(drawContext, x + option.getParentMenu().getFinalWidth(), y, mouseX, mouseY);
+        }
+    }
+
+    public static class ClassicRunnableRenderer implements SkinRenderer<RunnableOption> {
+        Color DARK_RED = new Color(116, 0, 0);
+        Color DARK_GREEN = new Color(24, 132, 0, 226);
+
+        @Override
+        public void render(DrawContext drawContext, RunnableOption option, int x, int y, int mouseX, int mouseY) {
+            option.setHeight(mc.textRenderer.fontHeight);
+            option.setWidth(mc.textRenderer.getWidth("Run: " + option.name));
+            int color = option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB();
+            drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
         }
     }
 
@@ -218,17 +254,6 @@ public class ClassicSkin extends Skin {
         }
     }
 
-    public static class ClassicEnumRenderer<E extends Enum<E>> implements SkinRenderer<EnumOption<E>> {
-        @Override
-        public void render(DrawContext drawContext, EnumOption<E> option, int x, int y, int mouseX, int mouseY) {
-            option.setHeight(mc.textRenderer.fontHeight + 1);
-            option.setWidth(mc.textRenderer.getWidth(option.name + ": " + option.value.name()) + 1);
-
-            drawContext.drawText(mc.textRenderer, Text.of(option.name + ": "), x, y, Color.WHITE.getRGB(), false);
-            drawContext.drawText(mc.textRenderer, Text.of(option.value.name()), x + mc.textRenderer.getWidth(option.name + ": ") + 1, y, Color.CYAN.getRGB(), false);
-        }
-    }
-
     public class ClassicListRenderer<E> implements SkinRenderer<ListOption<E>> {
         @Override
         public void render(DrawContext drawContext, ListOption<E> option, int x, int y, int mouseX, int mouseY) {
@@ -237,31 +262,6 @@ public class ClassicSkin extends Skin {
 
             drawContext.drawText(mc.textRenderer, Text.of(option.name + ": "), x, y + 1, Color.WHITE.getRGB(), false);
             drawContext.drawText(mc.textRenderer, Text.of(option.value.toString()), x + mc.textRenderer.getWidth(option.name + ": ") + 1, y + 1, Color.CYAN.getRGB(), false);
-        }
-    }
-
-    public static class ClassicSubMenuRenderer implements SkinRenderer<SubMenuOption> {
-        @Override
-        public void render(DrawContext drawContext, SubMenuOption option, int x, int y, int mouseX, int mouseY) {
-            int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
-            drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
-            option.setHeight(mc.textRenderer.fontHeight);
-            option.setWidth(mc.textRenderer.getWidth(option.name) + 1);
-
-            option.getSubMenu().render(drawContext, x + option.getParentMenu().getFinalWidth(), y, mouseX, mouseY);
-        }
-    }
-
-    public static class ClassicRunnableRenderer implements SkinRenderer<RunnableOption> {
-        Color DARK_RED = new Color(116, 0, 0);
-        Color DARK_GREEN = new Color(24, 132, 0, 226);
-
-        @Override
-        public void render(DrawContext drawContext, RunnableOption option, int x, int y, int mouseX, int mouseY) {
-            option.setHeight(mc.textRenderer.fontHeight);
-            option.setWidth(mc.textRenderer.getWidth("Run: " + option.name));
-            int color = option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB();
-            drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
         }
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/ClassicSkin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/ClassicSkin.java
@@ -1,0 +1,264 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem;
+
+import com.tanishisherewith.dynamichud.helpers.DrawHelper;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProperties;
+import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
+import com.tanishisherewith.dynamichud.utils.contextmenu.options.*;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.Text;
+
+import java.awt.*;
+
+/**
+ * This is one of the Skins provided by DynamicHUD featuring the classic rendering,
+ * which should be used when you have a low amount of settings and want quicker way of changing the settings.
+ */
+public class ClassicSkin extends Skin {
+    public static MinecraftClient mc = MinecraftClient.getInstance();
+
+    public ClassicSkin() {
+        super();
+
+        addRenderer(BooleanOption.class, new ClassicBooleanRenderer());
+        addRenderer(DoubleOption.class, new ClassicDoubleRenderer());
+        addRenderer(EnumOption.class, new ClassicEnumRenderer());
+        addRenderer(ListOption.class, new ClassicListRenderer());
+        addRenderer(SubMenuOption.class, new ClassicSubMenuRenderer());
+        addRenderer(RunnableOption.class, new ClassicRunnableRenderer());
+        addRenderer(ColorOption.class, new ClassicColorOptionRenderer());
+    }
+
+    @Override
+    public void renderContextMenu(DrawContext drawContext, ContextMenu contextMenu, int mouseX, int mouseY) {
+        this.contextMenu = contextMenu;
+        this.contextMenu.newScreenFlag = false;
+
+        MatrixStack matrices = drawContext.getMatrices();
+        ContextMenuProperties properties = contextMenu.getProperties();
+
+        // Draw the background
+        drawBackground(matrices, contextMenu, properties);
+
+        int yOffset = contextMenu.y + 3;
+        contextMenu.setWidth(10);
+        for (Option<?> option : contextMenu.getOptions()) {
+            if (!option.shouldRender()) continue;
+
+            // Adjust mouse coordinates based on the scale
+            if (contextMenu.getProperties().hoverEffect() && contextMenu.isMouseOver(mouseX, mouseY, contextMenu.x + 1, yOffset - 1, contextMenu.getFinalWidth() - 2, option.height)) {
+                drawBackground(matrices, contextMenu, properties, yOffset - 1,contextMenu.getFinalWidth(), option.height + 1, contextMenu.getProperties().getHoverColor().getRGB(),false);
+            }
+
+            option.render(drawContext, contextMenu.x + 4, yOffset, mouseX, mouseY);
+            contextMenu.setWidth(Math.max(contextMenu.getWidth(), option.width));
+            yOffset += option.height + 1;
+        }
+        contextMenu.setWidth(contextMenu.getWidth() + properties.getPadding());
+        contextMenu.setFinalWidth(contextMenu.getWidth());
+        contextMenu.height = (yOffset - contextMenu.y);
+
+        // Draw the border if needed
+        if (properties.shouldDrawBorder()) {
+            drawBorder(matrices, contextMenu, properties);
+        }
+    }
+
+    private void drawBackground(MatrixStack matrices, ContextMenu contextMenu, ContextMenuProperties properties) {
+        drawBackground(matrices, contextMenu, properties, contextMenu.y,contextMenu.getWidth(), contextMenu.height, properties.getBackgroundColor().getRGB(),properties.shadow());
+    }
+
+    private void drawBackground(MatrixStack matrices, ContextMenu contextMenu, ContextMenuProperties properties, int yOffset,int width, int height, int color,boolean shadow) {
+        // Wow so good code.
+        if (properties.roundedCorners()) {
+            if(shadow){
+                DrawHelper.drawRoundedRectangleWithShadowBadWay(matrices.peek().getPositionMatrix(),
+                        contextMenu.x,
+                        yOffset,
+                        width,
+                        height,
+                        properties.getCornerRadius(),
+                        color,
+                        150,
+                        1,
+                        1
+                );
+            }else {
+                DrawHelper.drawRoundedRectangle(matrices.peek().getPositionMatrix(),
+                        contextMenu.x,
+                        yOffset,
+                        width,
+                        height,
+                        properties.getCornerRadius(),
+                        color
+                );
+            }
+        } else {
+            if(shadow){
+                DrawHelper.drawRectangleWithShadowBadWay(matrices.peek().getPositionMatrix(),
+                        contextMenu.x,
+                        yOffset,
+                        width,
+                        height,
+                        color,
+                        150,
+                        1,
+                        1
+                );
+            }else {
+                DrawHelper.drawRectangle(matrices.peek().getPositionMatrix(),
+                        contextMenu.x,
+                        yOffset,
+                        width,
+                        height,
+                        color
+                );
+            }
+        }
+    }
+
+    private void drawBorder(MatrixStack matrices, ContextMenu contextMenu, ContextMenuProperties properties) {
+        if (properties.roundedCorners()) {
+            DrawHelper.drawOutlineRoundedBox(matrices.peek().getPositionMatrix(),
+                    contextMenu.x,
+                    contextMenu.y,
+                    contextMenu.getWidth(),
+                    contextMenu.height,
+                    properties.getCornerRadius(),
+                    properties.getBorderWidth(),
+                    properties.getBorderColor().getRGB()
+            );
+        } else {
+            DrawHelper.drawOutlineBox(matrices.peek().getPositionMatrix(),
+                    contextMenu.x,
+                    contextMenu.y,
+                    contextMenu.getWidth(),
+                    contextMenu.height,
+                    properties.getBorderWidth(),
+                    properties.getBorderColor().getRGB()
+            );
+        }
+    }
+
+    public static class ClassicBooleanRenderer implements SkinRenderer<BooleanOption> {
+        @Override
+        public void render(DrawContext drawContext, BooleanOption option, int x, int y, int mouseX, int mouseY) {
+            int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
+            drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
+            option.height = mc.textRenderer.fontHeight;
+            option.width = mc.textRenderer.getWidth(option.name) + 1;
+        }
+    }
+
+    public static class ClassicColorOptionRenderer implements SkinRenderer<ColorOption> {
+        @Override
+        public void render(DrawContext drawContext, ColorOption option, int x, int y, int mouseX, int mouseY) {
+            int color = option.isVisible ? Color.GREEN.getRGB() : Color.RED.getRGB();
+            drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
+            option.height = mc.textRenderer.fontHeight;
+            option.width = mc.textRenderer.getWidth(option.name) + 1;
+
+            int shadowOpacity = Math.min(option.value.getAlpha(),90);
+            DrawHelper.drawRoundedRectangleWithShadowBadWay(drawContext.getMatrices().peek().getPositionMatrix(),
+                    x + option.width,
+                    y - 1,
+                    8,
+                    8,
+                    2,
+                    option.value.getRGB(),
+                    shadowOpacity,
+                    1,
+                    1);
+
+            option.getColorPicker().render(drawContext, x + option.parentMenu.getFinalWidth() + 7, y - 10);
+        }
+    }
+
+    public class ClassicDoubleRenderer implements SkinRenderer<DoubleOption> {
+        @Override
+        public void render(DrawContext drawContext, DoubleOption option, int x, int y, int mouseX, int mouseY) {
+            option.width = Math.max(35, contextMenu != null ? contextMenu.getFinalWidth() - option.getProperties().getPadding() - 2 : 0);
+            option.height = 16;
+
+            // Draw the label
+            TextRenderer textRenderer = mc.textRenderer;
+            DrawHelper.scaleAndPosition(drawContext.getMatrices(), x, y, 0.7f);
+            String labelText = option.name + ": " + String.format("%.1f", option.value);
+            int labelWidth = textRenderer.getWidth(labelText);
+            option.width = Math.max(option.width, labelWidth);
+            drawContext.drawTextWithShadow(textRenderer, labelText, x, y + 1, 0xFFFFFFFF);
+            DrawHelper.stopScaling(drawContext.getMatrices());
+
+            float handleWidth = 3;
+            float handleHeight = 8;
+            double handleX = x + (option.value - option.minValue) / (option.maxValue - option.minValue) * (option.width - handleWidth);
+            double handleY = y + textRenderer.fontHeight + 1 + ((2 - handleHeight) / 2);
+
+            // Draw the slider
+            option.drawSlider(drawContext, x, y + textRenderer.fontHeight + 1, option.width, handleX);
+
+            // Draw the handle
+
+            DrawHelper.drawRoundedRectangleWithShadowBadWay(drawContext.getMatrices().peek().getPositionMatrix(),
+                    (float) handleX,
+                    (float) handleY,
+                    handleWidth,
+                    handleHeight,
+                    1,
+                    0xFFFFFFFF,
+                    90,
+                    0.6f,
+                    0.6f);
+        }
+    }
+
+    public static class ClassicEnumRenderer<E extends Enum<E>> implements SkinRenderer<EnumOption<E>> {
+        @Override
+        public void render(DrawContext drawContext, EnumOption<E> option, int x, int y, int mouseX, int mouseY) {
+            option.height = mc.textRenderer.fontHeight + 1;
+            option.width = mc.textRenderer.getWidth(option.name + ": " + option.value.name()) + 1;
+
+            drawContext.drawText(mc.textRenderer, Text.of(option.name + ": "), x, y, Color.WHITE.getRGB(), false);
+            drawContext.drawText(mc.textRenderer, Text.of(option.value.name()), x + mc.textRenderer.getWidth(option.name + ": ") + 1, y, Color.CYAN.getRGB(), false);
+        }
+    }
+
+    public class ClassicListRenderer<E> implements SkinRenderer<ListOption<E>> {
+        @Override
+        public void render(DrawContext drawContext, ListOption<E> option, int x, int y, int mouseX, int mouseY) {
+            option.height = mc.textRenderer.fontHeight + 1;
+            option.width = mc.textRenderer.getWidth(option.name + ": " + option.value.toString()) + 1;
+
+            drawContext.drawText(mc.textRenderer, Text.of(option.name + ": "), x, y + 1, Color.WHITE.getRGB(), false);
+            drawContext.drawText(mc.textRenderer, Text.of(option.value.toString()), x + mc.textRenderer.getWidth(option.name + ": ") + 1, y + 1, Color.CYAN.getRGB(), false);
+        }
+    }
+
+    public static class ClassicSubMenuRenderer implements SkinRenderer<SubMenuOption> {
+        @Override
+        public void render(DrawContext drawContext, SubMenuOption option, int x, int y, int mouseX, int mouseY) {
+            int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
+            drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
+            option.height = mc.textRenderer.fontHeight;
+            option.width = mc.textRenderer.getWidth(option.name) + 1;
+
+            option.getSubMenu().render(drawContext, x + option.getParentMenu().finalWidth, y, mouseX, mouseY);
+        }
+    }
+
+    public static class ClassicRunnableRenderer implements SkinRenderer<RunnableOption> {
+        Color DARK_RED = new Color(116, 0, 0);
+        Color DARK_GREEN = new Color(24, 132, 0, 226);
+
+        @Override
+        public void render(DrawContext drawContext, RunnableOption option, int x, int y, int mouseX, int mouseY) {
+            option.height = mc.textRenderer.fontHeight;
+            option.width = mc.textRenderer.getWidth("Run: " + option.name);
+            int color = option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB();
+            drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
+        }
+    }
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/ClassicSkin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/ClassicSkin.java
@@ -30,12 +30,13 @@ public class ClassicSkin extends Skin {
         addRenderer(SubMenuOption.class, new ClassicSubMenuRenderer());
         addRenderer(RunnableOption.class, new ClassicRunnableRenderer());
         addRenderer(ColorOption.class, new ClassicColorOptionRenderer());
+
+        setCreateNewScreen(false);
     }
 
     @Override
     public void renderContextMenu(DrawContext drawContext, ContextMenu contextMenu, int mouseX, int mouseY) {
         this.contextMenu = contextMenu;
-        this.contextMenu.newScreenFlag = false;
 
         MatrixStack matrices = drawContext.getMatrices();
         ContextMenuProperties properties = contextMenu.getProperties();
@@ -49,17 +50,17 @@ public class ClassicSkin extends Skin {
             if (!option.shouldRender()) continue;
 
             // Adjust mouse coordinates based on the scale
-            if (contextMenu.getProperties().hoverEffect() && contextMenu.isMouseOver(mouseX, mouseY, contextMenu.x + 1, yOffset - 1, contextMenu.getFinalWidth() - 2, option.height)) {
-                drawBackground(matrices, contextMenu, properties, yOffset - 1,contextMenu.getFinalWidth(), option.height + 1, contextMenu.getProperties().getHoverColor().getRGB(),false);
+            if (contextMenu.getProperties().hoverEffect() && contextMenu.isMouseOver(mouseX, mouseY, contextMenu.x + 1, yOffset - 1, contextMenu.getFinalWidth() - 2, option.getHeight())) {
+                drawBackground(matrices, contextMenu, properties, yOffset - 1,contextMenu.getFinalWidth(), option.getHeight() + 1, contextMenu.getProperties().getHoverColor().getRGB(),false);
             }
 
             option.render(drawContext, contextMenu.x + 4, yOffset, mouseX, mouseY);
-            contextMenu.setWidth(Math.max(contextMenu.getWidth(), option.width));
-            yOffset += option.height + 1;
+            contextMenu.setWidth(Math.max(contextMenu.getWidth(), option.getWidth()));
+            yOffset += option.getHeight() + 1;
         }
         contextMenu.setWidth(contextMenu.getWidth() + properties.getPadding());
         contextMenu.setFinalWidth(contextMenu.getWidth());
-        contextMenu.height = (yOffset - contextMenu.y);
+        contextMenu.setHeight(yOffset - contextMenu.y);
 
         // Draw the border if needed
         if (properties.shouldDrawBorder()) {
@@ -68,7 +69,7 @@ public class ClassicSkin extends Skin {
     }
 
     private void drawBackground(MatrixStack matrices, ContextMenu contextMenu, ContextMenuProperties properties) {
-        drawBackground(matrices, contextMenu, properties, contextMenu.y,contextMenu.getWidth(), contextMenu.height, properties.getBackgroundColor().getRGB(),properties.shadow());
+        drawBackground(matrices, contextMenu, properties, contextMenu.y,contextMenu.getWidth(), contextMenu.getHeight(), properties.getBackgroundColor().getRGB(),properties.shadow());
     }
 
     private void drawBackground(MatrixStack matrices, ContextMenu contextMenu, ContextMenuProperties properties, int yOffset,int width, int height, int color,boolean shadow) {
@@ -126,7 +127,7 @@ public class ClassicSkin extends Skin {
                     contextMenu.x,
                     contextMenu.y,
                     contextMenu.getWidth(),
-                    contextMenu.height,
+                    contextMenu.getHeight(),
                     properties.getCornerRadius(),
                     properties.getBorderWidth(),
                     properties.getBorderColor().getRGB()
@@ -136,7 +137,7 @@ public class ClassicSkin extends Skin {
                     contextMenu.x,
                     contextMenu.y,
                     contextMenu.getWidth(),
-                    contextMenu.height,
+                    contextMenu.getHeight(),
                     properties.getBorderWidth(),
                     properties.getBorderColor().getRGB()
             );
@@ -148,8 +149,8 @@ public class ClassicSkin extends Skin {
         public void render(DrawContext drawContext, BooleanOption option, int x, int y, int mouseX, int mouseY) {
             int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
             drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
-            option.height = mc.textRenderer.fontHeight;
-            option.width = mc.textRenderer.getWidth(option.name) + 1;
+            option.setHeight(mc.textRenderer.fontHeight);
+            option.setWidth(mc.textRenderer.getWidth(option.name) + 1);
         }
     }
 
@@ -158,12 +159,12 @@ public class ClassicSkin extends Skin {
         public void render(DrawContext drawContext, ColorOption option, int x, int y, int mouseX, int mouseY) {
             int color = option.isVisible ? Color.GREEN.getRGB() : Color.RED.getRGB();
             drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
-            option.height = mc.textRenderer.fontHeight;
-            option.width = mc.textRenderer.getWidth(option.name) + 1;
+            option.setHeight(mc.textRenderer.fontHeight);
+            option.setWidth(mc.textRenderer.getWidth(option.name) + 1);
 
             int shadowOpacity = Math.min(option.value.getAlpha(),90);
             DrawHelper.drawRoundedRectangleWithShadowBadWay(drawContext.getMatrices().peek().getPositionMatrix(),
-                    x + option.width,
+                    x + option.getWidth(),
                     y - 1,
                     8,
                     8,
@@ -180,25 +181,27 @@ public class ClassicSkin extends Skin {
     public class ClassicDoubleRenderer implements SkinRenderer<DoubleOption> {
         @Override
         public void render(DrawContext drawContext, DoubleOption option, int x, int y, int mouseX, int mouseY) {
-            option.width = Math.max(35, contextMenu != null ? contextMenu.getFinalWidth() - option.getProperties().getPadding() - 2 : 0);
-            option.height = 16;
+            option.setWidth(Math.max(35, contextMenu != null ? contextMenu.getFinalWidth() - option.getProperties().getPadding() - 2 : 0));
+            option.setHeight(16);
 
             // Draw the label
             TextRenderer textRenderer = mc.textRenderer;
             DrawHelper.scaleAndPosition(drawContext.getMatrices(), x, y, 0.7f);
             String labelText = option.name + ": " + String.format("%.1f", option.value);
             int labelWidth = textRenderer.getWidth(labelText);
-            option.width = Math.max(option.width, labelWidth);
+
+            option.setWidth(Math.max(option.getWidth(), labelWidth));
+
             drawContext.drawTextWithShadow(textRenderer, labelText, x, y + 1, 0xFFFFFFFF);
             DrawHelper.stopScaling(drawContext.getMatrices());
 
             float handleWidth = 3;
             float handleHeight = 8;
-            double handleX = x + (option.value - option.minValue) / (option.maxValue - option.minValue) * (option.width - handleWidth);
+            double handleX = x + (option.value - option.minValue) / (option.maxValue - option.minValue) * (option.getWidth() - handleWidth);
             double handleY = y + textRenderer.fontHeight + 1 + ((2 - handleHeight) / 2);
 
             // Draw the slider
-            option.drawSlider(drawContext, x, y + textRenderer.fontHeight + 1, option.width, handleX);
+            option.drawSlider(drawContext, x, y + textRenderer.fontHeight + 1, option.getWidth(), handleX);
 
             // Draw the handle
 
@@ -218,8 +221,8 @@ public class ClassicSkin extends Skin {
     public static class ClassicEnumRenderer<E extends Enum<E>> implements SkinRenderer<EnumOption<E>> {
         @Override
         public void render(DrawContext drawContext, EnumOption<E> option, int x, int y, int mouseX, int mouseY) {
-            option.height = mc.textRenderer.fontHeight + 1;
-            option.width = mc.textRenderer.getWidth(option.name + ": " + option.value.name()) + 1;
+            option.setHeight(mc.textRenderer.fontHeight + 1);
+            option.setWidth(mc.textRenderer.getWidth(option.name + ": " + option.value.name()) + 1);
 
             drawContext.drawText(mc.textRenderer, Text.of(option.name + ": "), x, y, Color.WHITE.getRGB(), false);
             drawContext.drawText(mc.textRenderer, Text.of(option.value.name()), x + mc.textRenderer.getWidth(option.name + ": ") + 1, y, Color.CYAN.getRGB(), false);
@@ -229,8 +232,8 @@ public class ClassicSkin extends Skin {
     public class ClassicListRenderer<E> implements SkinRenderer<ListOption<E>> {
         @Override
         public void render(DrawContext drawContext, ListOption<E> option, int x, int y, int mouseX, int mouseY) {
-            option.height = mc.textRenderer.fontHeight + 1;
-            option.width = mc.textRenderer.getWidth(option.name + ": " + option.value.toString()) + 1;
+            option.setHeight(mc.textRenderer.fontHeight + 1);
+            option.setWidth(mc.textRenderer.getWidth(option.name + ": " + option.value.toString()) + 1);
 
             drawContext.drawText(mc.textRenderer, Text.of(option.name + ": "), x, y + 1, Color.WHITE.getRGB(), false);
             drawContext.drawText(mc.textRenderer, Text.of(option.value.toString()), x + mc.textRenderer.getWidth(option.name + ": ") + 1, y + 1, Color.CYAN.getRGB(), false);
@@ -242,10 +245,10 @@ public class ClassicSkin extends Skin {
         public void render(DrawContext drawContext, SubMenuOption option, int x, int y, int mouseX, int mouseY) {
             int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
             drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
-            option.height = mc.textRenderer.fontHeight;
-            option.width = mc.textRenderer.getWidth(option.name) + 1;
+            option.setHeight(mc.textRenderer.fontHeight);
+            option.setWidth(mc.textRenderer.getWidth(option.name) + 1);
 
-            option.getSubMenu().render(drawContext, x + option.getParentMenu().finalWidth, y, mouseX, mouseY);
+            option.getSubMenu().render(drawContext, x + option.getParentMenu().getFinalWidth(), y, mouseX, mouseY);
         }
     }
 
@@ -255,8 +258,8 @@ public class ClassicSkin extends Skin {
 
         @Override
         public void render(DrawContext drawContext, RunnableOption option, int x, int y, int mouseX, int mouseY) {
-            option.height = mc.textRenderer.fontHeight;
-            option.width = mc.textRenderer.getWidth("Run: " + option.name);
+            option.setHeight(mc.textRenderer.fontHeight);
+            option.setWidth(mc.textRenderer.getWidth("Run: " + option.name));
             int color = option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB();
             drawContext.drawText(mc.textRenderer, Text.of(option.name), x, y, color, false);
         }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/MinecraftSkin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/MinecraftSkin.java
@@ -8,7 +8,6 @@ import com.tanishisherewith.dynamichud.utils.contextmenu.options.*;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ButtonTextures;
-import net.minecraft.client.texture.Sprite;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
@@ -22,18 +21,16 @@ import java.awt.*;
  * It tries to imitate the minecraft look and provides various form of panel shades {@link PanelColor}
  */
 public class MinecraftSkin extends Skin {
-    private static final MinecraftClient mc = MinecraftClient.getInstance();
-    private static final int DEFAULT_SCROLLBAR_WIDTH = 10;
-    private static final int DEFAULT_PANEL_WIDTH = 248;
-    private static final int DEFAULT_PANEL_HEIGHT = 165;
-    private static final Identifier DEFAULT_BACKGROUND_PANEL = Identifier.of("minecraft", "textures/gui/demo_background.png");
-
     public static final ButtonTextures TEXTURES = new ButtonTextures(
             Identifier.ofVanilla("widget/button"),
             Identifier.ofVanilla("widget/button_disabled"),
             Identifier.ofVanilla("widget/button_highlighted")
     );
-
+    private static final MinecraftClient mc = MinecraftClient.getInstance();
+    private static final int DEFAULT_SCROLLBAR_WIDTH = 10;
+    private static final int DEFAULT_PANEL_WIDTH = 248;
+    private static final int DEFAULT_PANEL_HEIGHT = 165;
+    private static final Identifier DEFAULT_BACKGROUND_PANEL = Identifier.of("minecraft", "textures/gui/demo_background.png");
     private static final Identifier SCROLLER_TEXTURE = Identifier.ofVanilla("widget/scroller");
     private static final Identifier SCROLL_BAR_BACKGROUND = Identifier.ofVanilla("widget/scroller_background");
 
@@ -46,50 +43,6 @@ public class MinecraftSkin extends Skin {
     private int maxScrollOffset = 0;
     private double scrollVelocity = 0;
     private int imageX, imageY;
-
-    public enum PanelColor {
-        COFFEE_BROWN(0.6f, 0.3f, 0.1f, 0.9f),
-        CREAMY(1.0f, 0.9f, 0.8f, 0.9f),
-        DARK_PANEL(0.2f, 0.2f, 0.2f, 0.9f),
-        FOREST_GREEN(0.0f, 0.6f, 0.2f, 0.9f),
-        GOLDEN_YELLOW(1.0f, 0.8f, 0.0f, 0.9f),
-        LAVENDER(0.8f, 0.6f, 1.0f, 0.9f),
-        LIGHT_BLUE(0.6f, 0.8f, 1.0f, 0.9f),
-        LIME_GREEN(0.7f, 1.0f, 0.3f, 0.9f),
-        MIDNIGHT_PURPLE(0.3f, 0.0f, 0.5f, 0.9f),
-        OCEAN_BLUE(0.0f, 0.5f, 1.0f, 0.9f),
-        ROSE_PINK(1.0f, 0.4f, 0.6f, 0.9f),
-        SKY_BLUE(0.5f, 0.8f, 1.0f, 0.9f),
-        SOFT_GREEN(0.6f, 1.0f, 0.6f, 0.9f),
-        SUNSET_ORANGE(1.0f, 0.5f, 0.0f, 0.9f),
-        WARM_YELLOW(1.0f, 1.0f, 0.6f, 0.9f),
-        CUSTOM(0.0f, 0.0f, 0.0f, 0.0f); // PlaceHolder for custom colors
-
-        private float red;
-        private float green;
-        private float blue;
-        private float alpha;
-
-        PanelColor(float red, float green, float blue, float alpha) {
-            this.red = red;
-            this.green = green;
-            this.blue = blue;
-            this.alpha = alpha;
-        }
-
-        public void applyColor() {
-            RenderSystem.setShaderColor(red, green, blue, alpha);
-        }
-
-        public static PanelColor custom(float red, float green, float blue, float alpha) {
-            PanelColor custom = CUSTOM;
-            custom.red = red;
-            custom.green = green;
-            custom.blue = blue;
-            custom.alpha = alpha;
-            return custom;
-        }
-    }
 
     public MinecraftSkin(PanelColor color, Identifier backgroundPanel, int panelWidth, int panelHeight) {
         super();
@@ -108,8 +61,9 @@ public class MinecraftSkin extends Skin {
 
         setCreateNewScreen(true);
     }
+
     public MinecraftSkin(PanelColor color) {
-        this(color,DEFAULT_BACKGROUND_PANEL,DEFAULT_PANEL_WIDTH,DEFAULT_PANEL_HEIGHT);
+        this(color, DEFAULT_BACKGROUND_PANEL, DEFAULT_PANEL_WIDTH, DEFAULT_PANEL_HEIGHT);
     }
 
     @Override
@@ -122,7 +76,7 @@ public class MinecraftSkin extends Skin {
         int centerX = screenWidth / 2;
         int centerY = screenHeight / 2;
 
-        contextMenu.set(centerX,centerY,0);
+        contextMenu.set(centerX, centerY, 0);
 
         // Calculate the top-left corner of the image
         imageX = (screenWidth - panelWidth) / 2;
@@ -133,11 +87,11 @@ public class MinecraftSkin extends Skin {
         RenderSystem.enableDepthTest();
         panelColor.applyColor();
         drawContext.drawTexture(BACKGROUND_PANEL, imageX, imageY, 0, 0, panelWidth, panelHeight);
-        RenderSystem.setShaderColor(1.0f,1.0f,1.0f,1.0f);
-        drawContext.drawGuiTexture(TEXTURES.get(true, isMouseOver(mouseX,mouseY,imageX + 3,imageY + 3,14,14)), imageX + 3,imageY + 3,14,14);
-        drawContext.drawText(mc.textRenderer,"X",imageX + 10 - mc.textRenderer.getWidth("X")/2 ,imageY + 6,-1,true);
+        RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
+        drawContext.drawGuiTexture(TEXTURES.get(true, isMouseOver(mouseX, mouseY, imageX + 3, imageY + 3, 14, 14)), imageX + 3, imageY + 3, 14, 14);
+        drawContext.drawText(mc.textRenderer, "X", imageX + 10 - mc.textRenderer.getWidth("X") / 2, imageY + 6, -1, true);
 
-        DrawHelper.enableScissor(imageX,imageY + 2,screenWidth,panelHeight - 4);
+        DrawHelper.enableScissor(imageX, imageY + 2, screenWidth, panelHeight - 4);
         int yOffset = imageY + 10 - scrollOffset;
         contextMenu.setWidth(panelWidth - 4);
         contextMenu.setFinalWidth(panelWidth - 4);
@@ -171,15 +125,14 @@ public class MinecraftSkin extends Skin {
     private void drawScrollbar(DrawContext context) {
         int scrollbarX = imageX + panelWidth + 5;
         int scrollbarY = imageY;
-
-        // Draw scrollbar background
-        context.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-        RenderSystem.enableBlend();
-        RenderSystem.enableDepthTest();
-        context.drawGuiTexture(SCROLL_BAR_BACKGROUND, scrollbarX, scrollbarY, DEFAULT_SCROLLBAR_WIDTH, panelHeight);
-        context.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-
         if (maxScrollOffset > 0) {
+            // Draw scrollbar background
+            context.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            context.drawGuiTexture(SCROLL_BAR_BACKGROUND, scrollbarX, scrollbarY, DEFAULT_SCROLLBAR_WIDTH, panelHeight);
+            context.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+
             float scrollPercentage = (float) scrollOffset / maxScrollOffset;
             int handleHeight = Math.max(15, (int) ((float) panelHeight * (panelHeight / (float) contextMenu.getHeight())));
             int handleY = scrollbarY + (int) ((panelHeight - handleHeight) * scrollPercentage);
@@ -189,7 +142,7 @@ public class MinecraftSkin extends Skin {
         }
     }
 
-    private boolean isMouseOver(double mouseX, double mouseY, double x, double y,double width, double height){
+    private boolean isMouseOver(double mouseX, double mouseY, double x, double y, double width, double height) {
         return mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height;
     }
 
@@ -199,14 +152,13 @@ public class MinecraftSkin extends Skin {
             scrollOffset = MathHelper.clamp(scrollOffset, 0, maxScrollOffset);
 
             // Stop the scrolling if the velocity is very low or if we've reached the limits
-            if (Math.abs(scrollVelocity) < 0.12 || scrollOffset == 0 || scrollOffset-maxScrollOffset <= 3) {
+            if (Math.abs(scrollVelocity) < 0.12 || scrollOffset == 0 || scrollOffset - maxScrollOffset <= 3) {
                 scrollVelocity = 0;
             } else {
                 scrollVelocity *= 0.89; // Apply friction
             }
         }
     }
-
 
     @Override
     public void mouseScrolled(ContextMenu menu, double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
@@ -216,7 +168,7 @@ public class MinecraftSkin extends Skin {
 
     @Override
     public boolean mouseClicked(ContextMenu menu, double mouseX, double mouseY, int button) {
-        if(button == GLFW.GLFW_MOUSE_BUTTON_LEFT && isMouseOver(mouseX,mouseY,imageX + 3,imageY + 3,14,14)){
+        if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT && isMouseOver(mouseX, mouseY, imageX + 3, imageY + 3, 14, 14)) {
             contextMenu.close();
         }
 
@@ -239,10 +191,54 @@ public class MinecraftSkin extends Skin {
         return super.mouseDragged(menu, mouseX, mouseY, button, deltaX, deltaY);
     }
 
+    public enum PanelColor {
+        COFFEE_BROWN(0.6f, 0.3f, 0.1f, 0.9f),
+        CREAMY(1.0f, 0.9f, 0.8f, 0.9f),
+        DARK_PANEL(0.2f, 0.2f, 0.2f, 0.9f),
+        FOREST_GREEN(0.0f, 0.6f, 0.2f, 0.9f),
+        GOLDEN_YELLOW(1.0f, 0.8f, 0.0f, 0.9f),
+        LAVENDER(0.8f, 0.6f, 1.0f, 0.9f),
+        LIGHT_BLUE(0.6f, 0.8f, 1.0f, 0.9f),
+        LIME_GREEN(0.7f, 1.0f, 0.3f, 0.9f),
+        MIDNIGHT_PURPLE(0.3f, 0.0f, 0.5f, 0.9f),
+        OCEAN_BLUE(0.0f, 0.5f, 1.0f, 0.9f),
+        ROSE_PINK(1.0f, 0.4f, 0.6f, 0.9f),
+        SKY_BLUE(0.5f, 0.8f, 1.0f, 0.9f),
+        SOFT_GREEN(0.6f, 1.0f, 0.6f, 0.9f),
+        SUNSET_ORANGE(1.0f, 0.5f, 0.0f, 0.9f),
+        WARM_YELLOW(1.0f, 1.0f, 0.6f, 0.9f),
+        CUSTOM(0.0f, 0.0f, 0.0f, 0.0f); // PlaceHolder for custom colors
+
+        private float red;
+        private float green;
+        private float blue;
+        private float alpha;
+
+        PanelColor(float red, float green, float blue, float alpha) {
+            this.red = red;
+            this.green = green;
+            this.blue = blue;
+            this.alpha = alpha;
+        }
+
+        public static PanelColor custom(float red, float green, float blue, float alpha) {
+            PanelColor custom = CUSTOM;
+            custom.red = red;
+            custom.green = green;
+            custom.blue = blue;
+            custom.alpha = alpha;
+            return custom;
+        }
+
+        public void applyColor() {
+            RenderSystem.setShaderColor(red, green, blue, alpha);
+        }
+    }
+
     public class MinecraftBooleanRenderer implements SkinRenderer<BooleanOption> {
         @Override
         public void render(DrawContext drawContext, BooleanOption option, int x, int y, int mouseX, int mouseY) {
-            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
+            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25 / 2 - 5, -1, true);
 
             option.set(x + panelWidth - 75, y);
 
@@ -250,11 +246,11 @@ public class MinecraftSkin extends Skin {
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.getX(),y,width,20);
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX, mouseY)), option.getX(), y, width, 20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             Text text = option.getBooleanType().getText(option.value);
             int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
-            drawContext.drawText(mc.textRenderer,text,(int) (option.getX() + (width/2.0f) -(mc.textRenderer.getWidth(text)/2.0f)) ,y + 5,color,true);
+            drawContext.drawText(mc.textRenderer, text, (int) (option.getX() + (width / 2.0f) - (mc.textRenderer.getWidth(text) / 2.0f)), y + 5, color, true);
             //drawContext.drawTexture(BOOLEAN_TEXTURE);
 
             option.setHeight(25);
@@ -265,7 +261,7 @@ public class MinecraftSkin extends Skin {
 
         @Override
         public boolean mouseClicked(BooleanOption option, double mouseX, double mouseY, int button) {
-            if(mouseX >= option.getX() && mouseX <= option.getX() + 50 && mouseY >= option.getY() && mouseY <= option.getY() + option.getHeight()){
+            if (mouseX >= option.getX() && mouseX <= option.getX() + 50 && mouseY >= option.getY() && mouseY <= option.getY() + option.getHeight()) {
                 option.set(!option.get());
             }
             return SkinRenderer.super.mouseClicked(option, mouseX, mouseY, button);
@@ -275,16 +271,16 @@ public class MinecraftSkin extends Skin {
     public class MinecraftColorOptionRenderer implements SkinRenderer<ColorOption> {
         @Override
         public void render(DrawContext drawContext, ColorOption option, int x, int y, int mouseX, int mouseY) {
-            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
+            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25 / 2 - 5, -1, true);
 
-            option.set(x + panelWidth - 75 , y);
+            option.set(x + panelWidth - 75, y);
 
             int width = 20;
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(!option.isVisible, option.isMouseOver(mouseX,mouseY)), option.getX(),y,width,20);
-            int shadowOpacity = Math.min(option.value.getAlpha(),45);
+            drawContext.drawGuiTexture(TEXTURES.get(!option.isVisible, option.isMouseOver(mouseX, mouseY)), option.getX(), y, width, 20);
+            int shadowOpacity = Math.min(option.value.getAlpha(), 45);
             DrawHelper.drawRectangleWithShadowBadWay(drawContext.getMatrices().peek().getPositionMatrix(),
                     option.getX() + 4,
                     y + 4,
@@ -317,33 +313,34 @@ public class MinecraftSkin extends Skin {
 
         @Override
         public void render(DrawContext drawContext, DoubleOption option, int x, int y, int mouseX, int mouseY) {
-            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
+            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25 / 2 - 5, -1, true);
 
             option.setWidth(panelWidth - 150);
             option.setHeight(25);
 
-            option.set(x + panelWidth - 122,y);
+            option.set(x + panelWidth - 122, y);
             double sliderX = option.getX() + (option.value - option.minValue) / (option.maxValue - option.minValue) * (option.getWidth() - 8);
-            boolean isMouseOverHandle = isMouseOver(mouseX,mouseY, sliderX, y);
+            boolean isMouseOverHandle = isMouseOver(mouseX, mouseY, sliderX, y);
 
             RenderSystem.enableBlend();
             RenderSystem.defaultBlendFunc();
             RenderSystem.enableDepthTest();
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-            drawContext.drawGuiTexture(option.isMouseOver(mouseX,mouseY)? HIGHLIGHTED_TEXTURE : TEXTURE, option.getX(), y, option.getWidth(), 20);
-            drawContext.drawGuiTexture(isMouseOverHandle ? HANDLE_HIGHLIGHTED_TEXTURE : HANDLE_TEXTURE , (int) Math.round(sliderX), y, 8, 20);
+            drawContext.drawGuiTexture(option.isMouseOver(mouseX, mouseY) ? HIGHLIGHTED_TEXTURE : TEXTURE, option.getX(), y, option.getWidth(), 20);
+            drawContext.drawGuiTexture(isMouseOverHandle ? HANDLE_HIGHLIGHTED_TEXTURE : HANDLE_TEXTURE, (int) Math.round(sliderX), y, 8, 20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
 
-            drawContext.drawText(mc.textRenderer, String.valueOf(option.value),option.getX() + option.getWidth()/2 - mc.textRenderer.getWidth(option.value.toString())/2 ,y + 5,16777215,false);
+            drawContext.drawText(mc.textRenderer, String.valueOf(option.value), option.getX() + option.getWidth() / 2 - mc.textRenderer.getWidth(option.value.toString()) / 2, y + 5, 16777215, false);
         }
-        private boolean isMouseOver(double mouseX, double mouseY, double x, double y){
+
+        private boolean isMouseOver(double mouseX, double mouseY, double x, double y) {
             return mouseX >= x && mouseX <= x + 10 && mouseY >= y && mouseY <= y + 20;
         }
 
         @Override
         public boolean mouseClicked(DoubleOption option, double mouseX, double mouseY, int button) {
-            return isMouseOver(mouseX,mouseY,option.getX(),option.getY());
+            return isMouseOver(mouseX, mouseY, option.getX(), option.getY());
         }
     }
 
@@ -365,17 +362,17 @@ public class MinecraftSkin extends Skin {
             option.setHeight(25);
             option.setWidth(maxWidth);
 
-            drawContext.drawText(mc.textRenderer, option.name + ": ", x + 15, y + 25/2 - 5, -1, true);
+            drawContext.drawText(mc.textRenderer, option.name + ": ", x + 15, y + 25 / 2 - 5, -1, true);
 
             option.set(x + panelWidth - maxWidth - 25, y);
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.getX(),y,maxWidth,20);
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX, mouseY)), option.getX(), y, maxWidth, 20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             String text = option.get().toString();
-            drawContext.drawText(mc.textRenderer,text,option.getX() + maxWidth/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.CYAN.getRGB(),true);
+            drawContext.drawText(mc.textRenderer, text, option.getX() + maxWidth / 2 - mc.textRenderer.getWidth(text) / 2, y + 5, Color.CYAN.getRGB(), true);
         }
     }
 
@@ -397,17 +394,17 @@ public class MinecraftSkin extends Skin {
             option.setHeight(25);
             option.setWidth(maxWidth);
 
-            drawContext.drawText(mc.textRenderer, option.name + ": ", x + 15, y + 25/2 - 5, -1, true);
+            drawContext.drawText(mc.textRenderer, option.name + ": ", x + 15, y + 25 / 2 - 5, -1, true);
 
             option.set(x + panelWidth - maxWidth - 25, y);
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.getX(),y,maxWidth,20);
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX, mouseY)), option.getX(), y, maxWidth, 20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             String text = option.get().toString();
-            drawContext.drawText(mc.textRenderer,text,option.getX() + maxWidth/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.CYAN.getRGB(),true);
+            drawContext.drawText(mc.textRenderer, text, option.getX() + maxWidth / 2 - mc.textRenderer.getWidth(text) / 2, y + 5, Color.CYAN.getRGB(), true);
         }
     }
 
@@ -417,17 +414,17 @@ public class MinecraftSkin extends Skin {
             option.setHeight(20);
             option.setWidth(30);
 
-            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
+            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25 / 2 - 5, -1, true);
 
             option.set(x + panelWidth - 75, y);
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.getX(),y, option.getWidth(),20);
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX, mouseY)), option.getX(), y, option.getWidth(), 20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             String text = "Open";
-            drawContext.drawText(mc.textRenderer,text,option.getX() +  option.getWidth()/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.YELLOW.getRGB(),true);
+            drawContext.drawText(mc.textRenderer, text, option.getX() + option.getWidth() / 2 - mc.textRenderer.getWidth(text) / 2, y + 5, Color.YELLOW.getRGB(), true);
 
             option.getSubMenu().render(drawContext, x + option.getParentMenu().getFinalWidth(), y, mouseX, mouseY);
         }
@@ -442,16 +439,16 @@ public class MinecraftSkin extends Skin {
             option.setHeight(25);
             option.setWidth(26);
 
-            drawContext.drawText(mc.textRenderer, option.name.replaceFirst("Run: ","") + ": ", x + 15, y + 25/2 - 5, -1, true);
+            drawContext.drawText(mc.textRenderer, option.name.replaceFirst("Run: ", "") + ": ", x + 15, y + 25 / 2 - 5, -1, true);
 
             option.set(x + panelWidth - 75, y);
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(!option.value, option.isMouseOver(mouseX,mouseY)), option.getX(),y, option.getWidth(),20);
+            drawContext.drawGuiTexture(TEXTURES.get(!option.value, option.isMouseOver(mouseX, mouseY)), option.getX(), y, option.getWidth(), 20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-            drawContext.drawText(mc.textRenderer,"Run",option.getX() +  option.getWidth()/2 - mc.textRenderer.getWidth("Run")/2 ,y + 5, option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB(),true);
+            drawContext.drawText(mc.textRenderer, "Run", option.getX() + option.getWidth() / 2 - mc.textRenderer.getWidth("Run") / 2, y + 5, option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB(), true);
         }
     }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/MinecraftSkin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/MinecraftSkin.java
@@ -32,22 +32,22 @@ public class MinecraftSkin extends Skin {
     private double scrollVelocity = 0;
 
     public enum PanelColor {
-        DARK_PANEL(0.2f, 0.2f, 0.2f, 0.9f),
+        COFFEE_BROWN(0.6f, 0.3f, 0.1f, 0.9f),
         CREAMY(1.0f, 0.9f, 0.8f, 0.9f),
-        LIGHT_BLUE(0.6f, 0.8f, 1.0f, 0.9f),
-        SOFT_GREEN(0.6f, 1.0f, 0.6f, 0.9f),
-        WARM_YELLOW(1.0f, 1.0f, 0.6f, 0.9f),
-        SUNSET_ORANGE(1.0f, 0.5f, 0.0f, 0.9f),
-        OCEAN_BLUE(0.0f, 0.5f, 1.0f, 0.9f),
+        DARK_PANEL(0.2f, 0.2f, 0.2f, 0.9f),
         FOREST_GREEN(0.0f, 0.6f, 0.2f, 0.9f),
-        MIDNIGHT_PURPLE(0.3f, 0.0f, 0.5f, 0.9f),
         GOLDEN_YELLOW(1.0f, 0.8f, 0.0f, 0.9f),
+        LAVENDER(0.8f, 0.6f, 1.0f, 0.9f),
+        LIGHT_BLUE(0.6f, 0.8f, 1.0f, 0.9f),
+        LIME_GREEN(0.7f, 1.0f, 0.3f, 0.9f),
+        MIDNIGHT_PURPLE(0.3f, 0.0f, 0.5f, 0.9f),
+        OCEAN_BLUE(0.0f, 0.5f, 1.0f, 0.9f),
         ROSE_PINK(1.0f, 0.4f, 0.6f, 0.9f),
         SKY_BLUE(0.5f, 0.8f, 1.0f, 0.9f),
-        LIME_GREEN(0.7f, 1.0f, 0.3f, 0.9f),
-        COFFEE_BROWN(0.6f, 0.3f, 0.1f, 0.9f),
-        LAVENDER(0.8f, 0.6f, 1.0f, 0.9f),
-        CUSTOM(0.0f, 0.0f, 0.0f, 0.0f); // Placeholder for custom colors
+        SOFT_GREEN(0.6f, 1.0f, 0.6f, 0.9f),
+        SUNSET_ORANGE(1.0f, 0.5f, 0.0f, 0.9f),
+        WARM_YELLOW(1.0f, 1.0f, 0.6f, 0.9f),
+        CUSTOM(0.0f, 0.0f, 0.0f, 0.0f); // PlaceHolder for custom colors
 
         private float red;
         private float green;
@@ -90,9 +90,7 @@ public class MinecraftSkin extends Skin {
         this.panelWidth = panelWidth;
         this.BACKGROUND_PANEL = backgroundPanel;
 
-        if(contextMenu != null){
-            contextMenu.newScreenFlag = true;
-        }
+        setCreateNewScreen(true);
     }
     public MinecraftSkin(PanelColor color) {
         this(color,Identifier.of("minecraft","textures/gui/demo_background.png"),248,165);
@@ -101,10 +99,6 @@ public class MinecraftSkin extends Skin {
     @Override
     public void renderContextMenu(DrawContext drawContext, ContextMenu contextMenu, int mouseX, int mouseY) {
         this.contextMenu = contextMenu;
-        if (!contextMenu.newScreenFlag) {
-            contextMenu.newScreenFlag = true;
-            return;
-        }
 
         int screenWidth = mc.getWindow().getScaledWidth();
         int screenHeight = mc.getWindow().getScaledHeight();
@@ -136,19 +130,19 @@ public class MinecraftSkin extends Skin {
         for (Option<?> option : contextMenu.getOptions()) {
             if (!option.shouldRender()) continue;
 
-            if (yOffset >= imageY && yOffset <= maxYOffset - option.height + 4) {
+            if (yOffset >= imageY && yOffset <= maxYOffset - option.getHeight() + 4) {
                 option.render(drawContext, imageX + 4, yOffset, mouseX, mouseY);
             }
 
-            yOffset += option.height + 1;
+            yOffset += option.getHeight() + 1;
         }
 
-        contextMenu.height = (yOffset - imageY) + 25;
+        contextMenu.setHeight(yOffset - imageY + 25);
 
         applyMomentum();
 
         // Calculate max scroll offset
-        maxScrollOffset = Math.max(0, contextMenu.height - panelHeight + 10);
+        maxScrollOffset = Math.max(0, contextMenu.getHeight() - panelHeight + 10);
         scrollOffset = MathHelper.clamp(scrollOffset, 0, maxScrollOffset);
 
         // Disable scissor after rendering
@@ -197,29 +191,28 @@ public class MinecraftSkin extends Skin {
         public void render(DrawContext drawContext, BooleanOption option, int x, int y, int mouseX, int mouseY) {
             drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
 
-            option.x = x + panelWidth - 75;
-            option.y = y;
+            option.set(x + panelWidth - 75, y);
 
             int width = 50;
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.x,y,width,20);
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.getX(),y,width,20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             Text text = option.getBooleanType().getText(option.value);
             int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
-            drawContext.drawText(mc.textRenderer,text,(int) (option.x + (width/2.0f) -(mc.textRenderer.getWidth(text)/2.0f)) ,y + 5,color,true);
+            drawContext.drawText(mc.textRenderer,text,(int) (option.getX() + (width/2.0f) -(mc.textRenderer.getWidth(text)/2.0f)) ,y + 5,color,true);
             //drawContext.drawTexture(BOOLEAN_TEXTURE);
 
-            option.height = 25;
+            option.setHeight(25);
 
-            //Widths dont matter in this skin.
-            option.width = width;
+            //Widths dont matter in this skin
+            option.setWidth(width);
         }
 
         @Override
         public boolean mouseClicked(BooleanOption option, double mouseX, double mouseY, int button) {
-            if(mouseX >= option.x && mouseX <= option.x + 50 && mouseY >= option.y && mouseY <= option.y + option.height){
+            if(mouseX >= option.getX() && mouseX <= option.getX() + 50 && mouseY >= option.getY() && mouseY <= option.getY() + option.getHeight()){
                 option.set(!option.get());
             }
             return SkinRenderer.super.mouseClicked(option, mouseX, mouseY, button);
@@ -231,17 +224,16 @@ public class MinecraftSkin extends Skin {
         public void render(DrawContext drawContext, ColorOption option, int x, int y, int mouseX, int mouseY) {
             drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
 
-            option.x = x + panelWidth - 75;
-            option.y = y;
+            option.set(x + panelWidth - 75 , y);
 
             int width = 20;
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(!option.isVisible, option.isMouseOver(mouseX,mouseY)), option.x,y,width,20);
+            drawContext.drawGuiTexture(TEXTURES.get(!option.isVisible, option.isMouseOver(mouseX,mouseY)), option.getX(),y,width,20);
             int shadowOpacity = Math.min(option.value.getAlpha(),45);
             DrawHelper.drawRectangleWithShadowBadWay(drawContext.getMatrices().peek().getPositionMatrix(),
-                    option.x + 4,
+                    option.getX() + 4,
                     y + 4,
                     width - 8,
                     20 - 8,
@@ -252,8 +244,8 @@ public class MinecraftSkin extends Skin {
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
 
 
-            option.height = 25;
-            option.width = width;
+            option.setHeight(25);
+            option.setWidth(width);
 
             option.getColorPicker().render(drawContext, x + panelWidth + 10, y - 10);
         }
@@ -274,12 +266,11 @@ public class MinecraftSkin extends Skin {
         public void render(DrawContext drawContext, DoubleOption option, int x, int y, int mouseX, int mouseY) {
             drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
 
-            option.width = panelWidth - 150;
-            option.height = 25;
+            option.setWidth(panelWidth - 150);
+            option.setHeight(25);
 
-            option.x = x + panelWidth - 122;
-            option.y = y;
-            double sliderX = option.x + (option.value - option.minValue) / (option.maxValue - option.minValue) * (option.width - 8);
+            option.set(x + panelWidth - 122,y);
+            double sliderX = option.getX() + (option.value - option.minValue) / (option.maxValue - option.minValue) * (option.getWidth() - 8);
             boolean isMouseOverHandle = isMouseOver(mouseX,mouseY, sliderX, y);
 
             RenderSystem.enableBlend();
@@ -287,11 +278,11 @@ public class MinecraftSkin extends Skin {
             RenderSystem.enableDepthTest();
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-            drawContext.drawGuiTexture(option.isMouseOver(mouseX,mouseY)? HIGHLIGHTED_TEXTURE : TEXTURE, option.x, y, option.width, 20);
+            drawContext.drawGuiTexture(option.isMouseOver(mouseX,mouseY)? HIGHLIGHTED_TEXTURE : TEXTURE, option.getX(), y, option.getWidth(), 20);
             drawContext.drawGuiTexture(isMouseOverHandle ? HANDLE_HIGHLIGHTED_TEXTURE : HANDLE_TEXTURE , (int) Math.round(sliderX), y, 8, 20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
 
-            drawContext.drawText(mc.textRenderer, String.valueOf(option.value),option.x + option.width/2 - mc.textRenderer.getWidth(option.value.toString())/2 ,y + 5,16777215,false);
+            drawContext.drawText(mc.textRenderer, String.valueOf(option.value),option.getX() + option.getWidth()/2 - mc.textRenderer.getWidth(option.value.toString())/2 ,y + 5,16777215,false);
         }
         private boolean isMouseOver(double mouseX, double mouseY, double x, double y){
             return mouseX >= x && mouseX <= x + 10 && mouseY >= y && mouseY <= y + 20;
@@ -299,7 +290,7 @@ public class MinecraftSkin extends Skin {
 
         @Override
         public boolean mouseClicked(DoubleOption option, double mouseX, double mouseY, int button) {
-            return isMouseOver(mouseX,mouseY,option.x,option.y);
+            return isMouseOver(mouseX,mouseY,option.getX(),option.getY());
         }
     }
 
@@ -318,21 +309,20 @@ public class MinecraftSkin extends Skin {
         @Override
         public void render(DrawContext drawContext, EnumOption<E> option, int x, int y, int mouseX, int mouseY) {
             calculateMaxWidth(option);
-            option.height = 25;
-            option.width = maxWidth;
+            option.setHeight(25);
+            option.setWidth(maxWidth);
 
             drawContext.drawText(mc.textRenderer, option.name + ": ", x + 15, y + 25/2 - 5, -1, true);
 
-            option.x = x + panelWidth - maxWidth - 25;
-            option.y = y;
+            option.set(x + panelWidth - maxWidth - 25, y);
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.x,y,maxWidth,20);
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.getX(),y,maxWidth,20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             String text = option.get().toString();
-            drawContext.drawText(mc.textRenderer,text,option.x + maxWidth/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.CYAN.getRGB(),true);
+            drawContext.drawText(mc.textRenderer,text,option.getX() + maxWidth/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.CYAN.getRGB(),true);
         }
     }
 
@@ -351,44 +341,42 @@ public class MinecraftSkin extends Skin {
         @Override
         public void render(DrawContext drawContext, ListOption<E> option, int x, int y, int mouseX, int mouseY) {
             calculateMaxWidth(option);
-            option.height = 25;
-            option.width = maxWidth;
+            option.setHeight(25);
+            option.setWidth(maxWidth);
 
             drawContext.drawText(mc.textRenderer, option.name + ": ", x + 15, y + 25/2 - 5, -1, true);
 
-            option.x = x + panelWidth - maxWidth - 25;
-            option.y = y;
+            option.set(x + panelWidth - maxWidth - 25, y);
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.x,y,maxWidth,20);
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.getX(),y,maxWidth,20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             String text = option.get().toString();
-            drawContext.drawText(mc.textRenderer,text,option.x + maxWidth/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.CYAN.getRGB(),true);
+            drawContext.drawText(mc.textRenderer,text,option.getX() + maxWidth/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.CYAN.getRGB(),true);
         }
     }
 
     public class MinecraftSubMenuRenderer implements SkinRenderer<SubMenuOption> {
         @Override
         public void render(DrawContext drawContext, SubMenuOption option, int x, int y, int mouseX, int mouseY) {
-            option.height = 20;
-            option.width = 30;
+            option.setHeight(20);
+            option.setWidth(30);
 
             drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
 
-            option.x = x + panelWidth - 75;
-            option.y = y;
+            option.set(x + panelWidth - 75, y);
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.x,y, option.width,20);
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.getX(),y, option.getWidth(),20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             String text = "Open";
-            drawContext.drawText(mc.textRenderer,text,option.x +  option.width/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.YELLOW.getRGB(),true);
+            drawContext.drawText(mc.textRenderer,text,option.getX() +  option.getWidth()/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.YELLOW.getRGB(),true);
 
-            option.getSubMenu().render(drawContext, x + option.getParentMenu().finalWidth, y, mouseX, mouseY);
+            option.getSubMenu().render(drawContext, x + option.getParentMenu().getFinalWidth(), y, mouseX, mouseY);
         }
     }
 
@@ -398,22 +386,19 @@ public class MinecraftSkin extends Skin {
 
         @Override
         public void render(DrawContext drawContext, RunnableOption option, int x, int y, int mouseX, int mouseY) {
-            option.height = 25;
-            option.width = 26;
+            option.setHeight(25);
+            option.setWidth(26);
 
             drawContext.drawText(mc.textRenderer, option.name.replaceFirst("Run: ","") + ": ", x + 15, y + 25/2 - 5, -1, true);
 
-            option.x = x + panelWidth - 75;
-            option.y = y;
+            option.set(x + panelWidth - 75, y);
 
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.enableBlend();
             RenderSystem.enableDepthTest();
-            drawContext.drawGuiTexture(TEXTURES.get(!option.value, option.isMouseOver(mouseX,mouseY)), option.x,y, option.width,20);
+            drawContext.drawGuiTexture(TEXTURES.get(!option.value, option.isMouseOver(mouseX,mouseY)), option.getX(),y, option.getWidth(),20);
             drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-            drawContext.drawText(mc.textRenderer,"Run",option.x +  option.width/2 - mc.textRenderer.getWidth("Run")/2 ,y + 5, option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB(),true);
+            drawContext.drawText(mc.textRenderer,"Run",option.getX() +  option.getWidth()/2 - mc.textRenderer.getWidth("Run")/2 ,y + 5, option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB(),true);
         }
     }
-
-
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/MinecraftSkin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/MinecraftSkin.java
@@ -1,0 +1,419 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.tanishisherewith.dynamichud.helpers.DrawHelper;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
+import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
+import com.tanishisherewith.dynamichud.utils.contextmenu.options.*;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ButtonTextures;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+import org.lwjgl.glfw.GLFW;
+
+import java.awt.*;
+
+/**
+ * This is one of the Skins provided by DynamicHUD featuring the minecraft-like style rendering.
+ * It runs on a separate screen and provides more complex features like scrolling and larger dimension.
+ * It tries to imitate the minecraft look and provides various form of panel shades {@link PanelColor}
+ */
+public class MinecraftSkin extends Skin {
+    public static MinecraftClient mc = MinecraftClient.getInstance();
+    public Identifier BACKGROUND_PANEL;
+    private int scrollOffset = 0;
+    private int maxScrollOffset = 0;
+    private final int panelWidth;
+    private final int panelHeight;
+    private final PanelColor panelColor;
+    public static final ButtonTextures TEXTURES = new ButtonTextures(Identifier.ofVanilla("widget/button"), Identifier.ofVanilla("widget/button_disabled"), Identifier.ofVanilla("widget/button_highlighted"));
+    private double scrollVelocity = 0;
+
+    public enum PanelColor {
+        DARK_PANEL(0.2f, 0.2f, 0.2f, 0.9f),
+        CREAMY(1.0f, 0.9f, 0.8f, 0.9f),
+        LIGHT_BLUE(0.6f, 0.8f, 1.0f, 0.9f),
+        SOFT_GREEN(0.6f, 1.0f, 0.6f, 0.9f),
+        WARM_YELLOW(1.0f, 1.0f, 0.6f, 0.9f),
+        SUNSET_ORANGE(1.0f, 0.5f, 0.0f, 0.9f),
+        OCEAN_BLUE(0.0f, 0.5f, 1.0f, 0.9f),
+        FOREST_GREEN(0.0f, 0.6f, 0.2f, 0.9f),
+        MIDNIGHT_PURPLE(0.3f, 0.0f, 0.5f, 0.9f),
+        GOLDEN_YELLOW(1.0f, 0.8f, 0.0f, 0.9f),
+        ROSE_PINK(1.0f, 0.4f, 0.6f, 0.9f),
+        SKY_BLUE(0.5f, 0.8f, 1.0f, 0.9f),
+        LIME_GREEN(0.7f, 1.0f, 0.3f, 0.9f),
+        COFFEE_BROWN(0.6f, 0.3f, 0.1f, 0.9f),
+        LAVENDER(0.8f, 0.6f, 1.0f, 0.9f),
+        CUSTOM(0.0f, 0.0f, 0.0f, 0.0f); // Placeholder for custom colors
+
+        private float red;
+        private float green;
+        private float blue;
+        private float alpha;
+
+        PanelColor(float red, float green, float blue, float alpha) {
+            this.red = red;
+            this.green = green;
+            this.blue = blue;
+            this.alpha = alpha;
+        }
+
+        public void applyColor() {
+            RenderSystem.setShaderColor(red, green, blue, alpha);
+        }
+
+        public static PanelColor custom(float red, float green, float blue, float alpha) {
+            PanelColor custom = CUSTOM;
+            custom.red = red;
+            custom.green = green;
+            custom.blue = blue;
+            custom.alpha = alpha;
+            return custom;
+        }
+    }
+
+    public MinecraftSkin(PanelColor color, Identifier backgroundPanel, int panelWidth, int panelHeight) {
+        super();
+        this.panelColor = color;
+        addRenderer(BooleanOption.class, new MinecraftBooleanRenderer());
+        addRenderer(DoubleOption.class, new MinecraftDoubleRenderer());
+        addRenderer(EnumOption.class, new MinecraftEnumRenderer());
+        addRenderer(ListOption.class, new MinecraftListRenderer());
+        addRenderer(SubMenuOption.class, new MinecraftSubMenuRenderer());
+        addRenderer(RunnableOption.class, new MinecraftRunnableRenderer());
+        addRenderer(ColorOption.class, new MinecraftColorOptionRenderer());
+
+        this.panelHeight = panelHeight;
+        this.panelWidth = panelWidth;
+        this.BACKGROUND_PANEL = backgroundPanel;
+
+        if(contextMenu != null){
+            contextMenu.newScreenFlag = true;
+        }
+    }
+    public MinecraftSkin(PanelColor color) {
+        this(color,Identifier.of("minecraft","textures/gui/demo_background.png"),248,165);
+    }
+
+    @Override
+    public void renderContextMenu(DrawContext drawContext, ContextMenu contextMenu, int mouseX, int mouseY) {
+        this.contextMenu = contextMenu;
+        if (!contextMenu.newScreenFlag) {
+            contextMenu.newScreenFlag = true;
+            return;
+        }
+
+        int screenWidth = mc.getWindow().getScaledWidth();
+        int screenHeight = mc.getWindow().getScaledHeight();
+
+        int centerX = screenWidth / 2;
+        int centerY = screenHeight / 2;
+
+        contextMenu.set(centerX,centerY,0);
+
+        // Calculate the top-left corner of the image
+        int imageX = centerX - panelWidth / 2;
+        int imageY = centerY - panelHeight / 2;
+
+        RenderSystem.enableBlend();
+        RenderSystem.enableDepthTest();
+        panelColor.applyColor();
+        drawContext.drawTexture(BACKGROUND_PANEL, imageX, imageY, 0, 0, panelWidth, panelHeight);
+        RenderSystem.setShaderColor(1.0f,1.0f,1.0f,1.0f);
+        drawContext.drawGuiTexture(TEXTURES.get(true, isMouseOver(mouseX,mouseY,imageX + 3,imageY + 3,14,14)), imageX + 3,imageY + 3,14,14);
+        drawContext.drawText(mc.textRenderer,"X",imageX + 10 - mc.textRenderer.getWidth("X")/2 ,imageY + 6,-1,true);
+
+        DrawHelper.enableScissor(imageX,imageY + 2,screenWidth,panelHeight - 4);
+        int yOffset = imageY + 10 - scrollOffset;
+        contextMenu.setWidth(panelWidth - 4);
+        contextMenu.setFinalWidth(panelWidth - 4);
+        contextMenu.y = imageY;
+        int maxYOffset = imageY + panelHeight - 4;
+
+        for (Option<?> option : contextMenu.getOptions()) {
+            if (!option.shouldRender()) continue;
+
+            if (yOffset >= imageY && yOffset <= maxYOffset - option.height + 4) {
+                option.render(drawContext, imageX + 4, yOffset, mouseX, mouseY);
+            }
+
+            yOffset += option.height + 1;
+        }
+
+        contextMenu.height = (yOffset - imageY) + 25;
+
+        applyMomentum();
+
+        // Calculate max scroll offset
+        maxScrollOffset = Math.max(0, contextMenu.height - panelHeight + 10);
+        scrollOffset = MathHelper.clamp(scrollOffset, 0, maxScrollOffset);
+
+        // Disable scissor after rendering
+        DrawHelper.disableScissor();
+    }
+    private boolean isMouseOver(double mouseX, double mouseY, double x, double y,double width, double height){
+        return mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height;
+    }
+    private void applyMomentum() {
+        if (scrollVelocity != 0) {
+            scrollOffset += (int) scrollVelocity;
+            scrollOffset = MathHelper.clamp(scrollOffset, 0, maxScrollOffset);
+            scrollVelocity *= 0.9; //Friction
+
+            // Stop the scrolling if the velocity is very low
+            if (Math.abs(scrollVelocity) < 0.12) {
+                scrollVelocity = 0;
+            }
+        }
+    }
+
+    @Override
+    public void mouseScrolled(ContextMenu menu, double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+        scrollVelocity += verticalAmount;
+        super.mouseScrolled(menu, mouseX, mouseY, horizontalAmount, verticalAmount);
+    }
+
+    @Override
+    public boolean mouseClicked(ContextMenu menu, double mouseX, double mouseY, int button) {
+        int screenWidth = mc.getWindow().getScaledWidth();
+        int screenHeight = mc.getWindow().getScaledHeight();
+
+        // Calculate the top-left corner of the image
+        int imageX = (screenWidth - panelWidth) / 2;
+        int imageY = (screenHeight - panelHeight) / 2;
+
+        if(button == GLFW.GLFW_MOUSE_BUTTON_LEFT && isMouseOver(mouseX,mouseY,imageX + 3,imageY + 3,14,14)){
+            contextMenu.close();
+        }
+
+        return super.mouseClicked(menu, mouseX, mouseY, button);
+    }
+
+    public class MinecraftBooleanRenderer implements SkinRenderer<BooleanOption> {
+        @Override
+        public void render(DrawContext drawContext, BooleanOption option, int x, int y, int mouseX, int mouseY) {
+            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
+
+            option.x = x + panelWidth - 75;
+            option.y = y;
+
+            int width = 50;
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.x,y,width,20);
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            Text text = option.getBooleanType().getText(option.value);
+            int color = option.value ? Color.GREEN.getRGB() : Color.RED.getRGB();
+            drawContext.drawText(mc.textRenderer,text,(int) (option.x + (width/2.0f) -(mc.textRenderer.getWidth(text)/2.0f)) ,y + 5,color,true);
+            //drawContext.drawTexture(BOOLEAN_TEXTURE);
+
+            option.height = 25;
+
+            //Widths dont matter in this skin.
+            option.width = width;
+        }
+
+        @Override
+        public boolean mouseClicked(BooleanOption option, double mouseX, double mouseY, int button) {
+            if(mouseX >= option.x && mouseX <= option.x + 50 && mouseY >= option.y && mouseY <= option.y + option.height){
+                option.set(!option.get());
+            }
+            return SkinRenderer.super.mouseClicked(option, mouseX, mouseY, button);
+        }
+    }
+
+    public class MinecraftColorOptionRenderer implements SkinRenderer<ColorOption> {
+        @Override
+        public void render(DrawContext drawContext, ColorOption option, int x, int y, int mouseX, int mouseY) {
+            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
+
+            option.x = x + panelWidth - 75;
+            option.y = y;
+
+            int width = 20;
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            drawContext.drawGuiTexture(TEXTURES.get(!option.isVisible, option.isMouseOver(mouseX,mouseY)), option.x,y,width,20);
+            int shadowOpacity = Math.min(option.value.getAlpha(),45);
+            DrawHelper.drawRectangleWithShadowBadWay(drawContext.getMatrices().peek().getPositionMatrix(),
+                    option.x + 4,
+                    y + 4,
+                    width - 8,
+                    20 - 8,
+                    option.value.getRGB(),
+                    shadowOpacity,
+                    1,
+                    1);
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+
+
+            option.height = 25;
+            option.width = width;
+
+            option.getColorPicker().render(drawContext, x + panelWidth + 10, y - 10);
+        }
+    }
+
+    public class MinecraftDoubleRenderer implements SkinRenderer<DoubleOption> {
+        private static final Identifier TEXTURE = Identifier.ofVanilla("widget/slider");
+        private static final Identifier HIGHLIGHTED_TEXTURE = Identifier.ofVanilla("widget/slider_highlighted");
+        private static final Identifier HANDLE_TEXTURE = Identifier.ofVanilla("widget/slider_handle");
+        private static final Identifier HANDLE_HIGHLIGHTED_TEXTURE = Identifier.ofVanilla("widget/slider_handle_highlighted");
+
+        @Override
+        public void init(DoubleOption option) {
+            SkinRenderer.super.init(option);
+        }
+
+        @Override
+        public void render(DrawContext drawContext, DoubleOption option, int x, int y, int mouseX, int mouseY) {
+            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
+
+            option.width = panelWidth - 150;
+            option.height = 25;
+
+            option.x = x + panelWidth - 122;
+            option.y = y;
+            double sliderX = option.x + (option.value - option.minValue) / (option.maxValue - option.minValue) * (option.width - 8);
+            boolean isMouseOverHandle = isMouseOver(mouseX,mouseY, sliderX, y);
+
+            RenderSystem.enableBlend();
+            RenderSystem.defaultBlendFunc();
+            RenderSystem.enableDepthTest();
+
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            drawContext.drawGuiTexture(option.isMouseOver(mouseX,mouseY)? HIGHLIGHTED_TEXTURE : TEXTURE, option.x, y, option.width, 20);
+            drawContext.drawGuiTexture(isMouseOverHandle ? HANDLE_HIGHLIGHTED_TEXTURE : HANDLE_TEXTURE , (int) Math.round(sliderX), y, 8, 20);
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+
+            drawContext.drawText(mc.textRenderer, String.valueOf(option.value),option.x + option.width/2 - mc.textRenderer.getWidth(option.value.toString())/2 ,y + 5,16777215,false);
+        }
+        private boolean isMouseOver(double mouseX, double mouseY, double x, double y){
+            return mouseX >= x && mouseX <= x + 10 && mouseY >= y && mouseY <= y + 20;
+        }
+
+        @Override
+        public boolean mouseClicked(DoubleOption option, double mouseX, double mouseY, int button) {
+            return isMouseOver(mouseX,mouseY,option.x,option.y);
+        }
+    }
+
+    public class MinecraftEnumRenderer<E extends Enum<E>> implements SkinRenderer<EnumOption<E>> {
+        private int maxWidth = 50;
+
+        private void calculateMaxWidth(EnumOption<E> option) {
+            for (E enumConstant : option.getValues()) {
+                int width = mc.textRenderer.getWidth(enumConstant.name()) + 5;
+                if (width > maxWidth) {
+                    maxWidth = width;
+                }
+            }
+        }
+
+        @Override
+        public void render(DrawContext drawContext, EnumOption<E> option, int x, int y, int mouseX, int mouseY) {
+            calculateMaxWidth(option);
+            option.height = 25;
+            option.width = maxWidth;
+
+            drawContext.drawText(mc.textRenderer, option.name + ": ", x + 15, y + 25/2 - 5, -1, true);
+
+            option.x = x + panelWidth - maxWidth - 25;
+            option.y = y;
+
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.x,y,maxWidth,20);
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            String text = option.get().toString();
+            drawContext.drawText(mc.textRenderer,text,option.x + maxWidth/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.CYAN.getRGB(),true);
+        }
+    }
+
+    public class MinecraftListRenderer<E> implements SkinRenderer<ListOption<E>> {
+        private int maxWidth = 50;
+
+        private void calculateMaxWidth(ListOption<E> option) {
+            for (E listValues : option.getValues()) {
+                int width = mc.textRenderer.getWidth(listValues.toString()) + 5;
+                if (width > maxWidth) {
+                    maxWidth = width;
+                }
+            }
+        }
+
+        @Override
+        public void render(DrawContext drawContext, ListOption<E> option, int x, int y, int mouseX, int mouseY) {
+            calculateMaxWidth(option);
+            option.height = 25;
+            option.width = maxWidth;
+
+            drawContext.drawText(mc.textRenderer, option.name + ": ", x + 15, y + 25/2 - 5, -1, true);
+
+            option.x = x + panelWidth - maxWidth - 25;
+            option.y = y;
+
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.x,y,maxWidth,20);
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            String text = option.get().toString();
+            drawContext.drawText(mc.textRenderer,text,option.x + maxWidth/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.CYAN.getRGB(),true);
+        }
+    }
+
+    public class MinecraftSubMenuRenderer implements SkinRenderer<SubMenuOption> {
+        @Override
+        public void render(DrawContext drawContext, SubMenuOption option, int x, int y, int mouseX, int mouseY) {
+            option.height = 20;
+            option.width = 30;
+
+            drawContext.drawText(mc.textRenderer, option.name, x + 15, y + 25/2 - 5, -1, true);
+
+            option.x = x + panelWidth - 75;
+            option.y = y;
+
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            drawContext.drawGuiTexture(TEXTURES.get(true, option.isMouseOver(mouseX,mouseY)), option.x,y, option.width,20);
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            String text = "Open";
+            drawContext.drawText(mc.textRenderer,text,option.x +  option.width/2 - mc.textRenderer.getWidth(text)/2 ,y + 5,Color.YELLOW.getRGB(),true);
+
+            option.getSubMenu().render(drawContext, x + option.getParentMenu().finalWidth, y, mouseX, mouseY);
+        }
+    }
+
+    public class MinecraftRunnableRenderer implements SkinRenderer<RunnableOption> {
+        Color DARK_RED = new Color(116, 0, 0);
+        Color DARK_GREEN = new Color(24, 132, 0, 226);
+
+        @Override
+        public void render(DrawContext drawContext, RunnableOption option, int x, int y, int mouseX, int mouseY) {
+            option.height = 25;
+            option.width = 26;
+
+            drawContext.drawText(mc.textRenderer, option.name.replaceFirst("Run: ","") + ": ", x + 15, y + 25/2 - 5, -1, true);
+
+            option.x = x + panelWidth - 75;
+            option.y = y;
+
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            RenderSystem.enableBlend();
+            RenderSystem.enableDepthTest();
+            drawContext.drawGuiTexture(TEXTURES.get(!option.value, option.isMouseOver(mouseX,mouseY)), option.x,y, option.width,20);
+            drawContext.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            drawContext.drawText(mc.textRenderer,"Run",option.x +  option.width/2 - mc.textRenderer.getWidth("Run")/2 ,y + 5, option.value ? DARK_GREEN.getRGB() : DARK_RED.getRGB(),true);
+        }
+    }
+
+
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/MinecraftSkin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/MinecraftSkin.java
@@ -22,20 +22,30 @@ import java.awt.*;
  * It tries to imitate the minecraft look and provides various form of panel shades {@link PanelColor}
  */
 public class MinecraftSkin extends Skin {
-    public static MinecraftClient mc = MinecraftClient.getInstance();
-    public Identifier BACKGROUND_PANEL;
-    private int scrollOffset = 0;
-    private int maxScrollOffset = 0;
+    private static final MinecraftClient mc = MinecraftClient.getInstance();
+    private static final int DEFAULT_SCROLLBAR_WIDTH = 10;
+    private static final int DEFAULT_PANEL_WIDTH = 248;
+    private static final int DEFAULT_PANEL_HEIGHT = 165;
+    private static final Identifier DEFAULT_BACKGROUND_PANEL = Identifier.of("minecraft", "textures/gui/demo_background.png");
+
+    public static final ButtonTextures TEXTURES = new ButtonTextures(
+            Identifier.ofVanilla("widget/button"),
+            Identifier.ofVanilla("widget/button_disabled"),
+            Identifier.ofVanilla("widget/button_highlighted")
+    );
+
+    private static final Identifier SCROLLER_TEXTURE = Identifier.ofVanilla("widget/scroller");
+    private static final Identifier SCROLL_BAR_BACKGROUND = Identifier.ofVanilla("widget/scroller_background");
+
+    private final Identifier BACKGROUND_PANEL;
     private final int panelWidth;
     private final int panelHeight;
     private final PanelColor panelColor;
-    public static final ButtonTextures TEXTURES = new ButtonTextures(Identifier.ofVanilla("widget/button"), Identifier.ofVanilla("widget/button_disabled"), Identifier.ofVanilla("widget/button_highlighted"));
-    private static final Identifier SCROLLER = Identifier.ofVanilla("widget/scroller");
-    private static final Identifier SCROLL_BAR_BACKGROUND = Identifier.ofVanilla("widget/scroller_background");
-    private double scrollVelocity = 0;
-    public static int SCROLLBAR_WIDTH = 10;
 
-    int imageX, imageY;
+    private int scrollOffset = 0;
+    private int maxScrollOffset = 0;
+    private double scrollVelocity = 0;
+    private int imageX, imageY;
 
     public enum PanelColor {
         COFFEE_BROWN(0.6f, 0.3f, 0.1f, 0.9f),
@@ -99,7 +109,7 @@ public class MinecraftSkin extends Skin {
         setCreateNewScreen(true);
     }
     public MinecraftSkin(PanelColor color) {
-        this(color,Identifier.of("minecraft","textures/gui/demo_background.png"),248,165);
+        this(color,DEFAULT_BACKGROUND_PANEL,DEFAULT_PANEL_WIDTH,DEFAULT_PANEL_HEIGHT);
     }
 
     @Override
@@ -166,7 +176,7 @@ public class MinecraftSkin extends Skin {
         context.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.enableBlend();
         RenderSystem.enableDepthTest();
-        context.drawGuiTexture(SCROLL_BAR_BACKGROUND, scrollbarX, scrollbarY, SCROLLBAR_WIDTH, panelHeight);
+        context.drawGuiTexture(SCROLL_BAR_BACKGROUND, scrollbarX, scrollbarY, DEFAULT_SCROLLBAR_WIDTH, panelHeight);
         context.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
 
         if (maxScrollOffset > 0) {
@@ -175,7 +185,7 @@ public class MinecraftSkin extends Skin {
             int handleY = scrollbarY + (int) ((panelHeight - handleHeight) * scrollPercentage);
 
             // Draw scrollbar handle
-            context.drawGuiTexture(SCROLLER, scrollbarX, handleY, SCROLLBAR_WIDTH, handleHeight);
+            context.drawGuiTexture(SCROLLER_TEXTURE, scrollbarX, handleY, DEFAULT_SCROLLBAR_WIDTH, handleHeight);
         }
     }
 

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/Skin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/Skin.java
@@ -11,6 +11,7 @@ import java.util.Map;
 public abstract class Skin {
     protected ContextMenu contextMenu;
     protected Map<Class<? extends Option<?>>, SkinRenderer<? extends Option<?>>> renderers = new HashMap<>();
+    private boolean createNewScreen;
 
     public <T extends Option<?>> void addRenderer(Class<T> optionClass, SkinRenderer<? super T> renderer) {
         renderers.put(optionClass, renderer);
@@ -52,4 +53,12 @@ public abstract class Skin {
     public void keyPressed(ContextMenu menu, int key,int scanCode, int modifiers) {}
     public void keyReleased(ContextMenu menu, int key,int scanCode, int modifiers) {}
     public void mouseScrolled(ContextMenu menu, double mouseX, double mouseY, double horizontalAmount, double verticalAmount){}
+
+    public boolean shouldCreateNewScreen() {
+        return createNewScreen;
+    }
+
+    public void setCreateNewScreen(boolean createNewScreen) {
+        this.createNewScreen = createNewScreen;
+    }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/Skin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/Skin.java
@@ -1,0 +1,55 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem;
+
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
+import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProvider;
+import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
+import net.minecraft.client.gui.DrawContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class Skin {
+    protected ContextMenu contextMenu;
+    protected Map<Class<? extends Option<?>>, SkinRenderer<? extends Option<?>>> renderers = new HashMap<>();
+
+    public <T extends Option<?>> void addRenderer(Class<T> optionClass, SkinRenderer<? super T> renderer) {
+        renderers.put(optionClass, renderer);
+    }
+
+    public Skin(ContextMenu menu){
+        this.contextMenu = menu;
+    }
+    public Skin(){
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends Option<?>> SkinRenderer<T> getRenderer(Class<T> optionClass) {
+        return (SkinRenderer<T>) renderers.get(optionClass);
+    }
+
+    public void setContextMenu(ContextMenu contextMenu) {
+        this.contextMenu = contextMenu;
+    }
+
+    public void setRenderers(Map<Class<? extends Option<?>>, SkinRenderer<? extends Option<?>>> renderers) {
+        this.renderers = renderers;
+    }
+
+    public abstract void renderContextMenu(DrawContext drawContext, ContextMenu contextMenu, int mouseX, int mouseY);
+
+    public boolean mouseClicked(ContextMenu menu, double mouseX, double mouseY, int button) {
+        return false;
+    }
+
+    public boolean mouseReleased(ContextMenu menu, double mouseX, double mouseY, int button) {
+        return false;
+    }
+
+    public boolean mouseDragged(ContextMenu menu, double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        return false;
+    }
+
+    public void keyPressed(ContextMenu menu, int key,int scanCode, int modifiers) {}
+    public void keyReleased(ContextMenu menu, int key,int scanCode, int modifiers) {}
+    public void mouseScrolled(ContextMenu menu, double mouseX, double mouseY, double horizontalAmount, double verticalAmount){}
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/Skin.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/Skin.java
@@ -1,7 +1,6 @@
 package com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem;
 
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
-import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProvider;
 import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
 import net.minecraft.client.gui.DrawContext;
 
@@ -13,14 +12,15 @@ public abstract class Skin {
     protected Map<Class<? extends Option<?>>, SkinRenderer<? extends Option<?>>> renderers = new HashMap<>();
     private boolean createNewScreen;
 
-    public <T extends Option<?>> void addRenderer(Class<T> optionClass, SkinRenderer<? super T> renderer) {
-        renderers.put(optionClass, renderer);
-    }
-
-    public Skin(ContextMenu menu){
+    public Skin(ContextMenu menu) {
         this.contextMenu = menu;
     }
-    public Skin(){
+
+    public Skin() {
+    }
+
+    public <T extends Option<?>> void addRenderer(Class<T> optionClass, SkinRenderer<? super T> renderer) {
+        renderers.put(optionClass, renderer);
     }
 
     @SuppressWarnings("unchecked")
@@ -50,9 +50,14 @@ public abstract class Skin {
         return false;
     }
 
-    public void keyPressed(ContextMenu menu, int key,int scanCode, int modifiers) {}
-    public void keyReleased(ContextMenu menu, int key,int scanCode, int modifiers) {}
-    public void mouseScrolled(ContextMenu menu, double mouseX, double mouseY, double horizontalAmount, double verticalAmount){}
+    public void keyPressed(ContextMenu menu, int key, int scanCode, int modifiers) {
+    }
+
+    public void keyReleased(ContextMenu menu, int key, int scanCode, int modifiers) {
+    }
+
+    public void mouseScrolled(ContextMenu menu, double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+    }
 
     public boolean shouldCreateNewScreen() {
         return createNewScreen;

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/SkinRenderer.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/SkinRenderer.java
@@ -1,0 +1,26 @@
+package com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem;
+
+import com.tanishisherewith.dynamichud.utils.contextmenu.Option;
+import net.minecraft.client.gui.DrawContext;
+
+public interface SkinRenderer<T extends Option<?>> {
+    void render(DrawContext drawContext, T option, int x, int y, int mouseX, int mouseY);
+
+    default boolean mouseClicked(T option, double mouseX, double mouseY, int button) {
+        return option.isMouseOver(mouseX, mouseY);
+    }
+
+    default boolean mouseReleased(T option, double mouseX, double mouseY, int button) {
+        return option.isMouseOver(mouseX, mouseY);
+    }
+
+    default boolean mouseDragged(T option, double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        return option.isMouseOver(mouseX, mouseY);
+    }
+
+    default void keyPressed(T option, int key) {}
+
+    default void keyReleased(T option, int key) {}
+    default void mouseScrolled(T option, double mouseX, double mouseY, double horizontalAmount, double verticalAmount){}
+    default void init(T option){}
+}

--- a/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/SkinRenderer.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/utils/contextmenu/skinsystem/SkinRenderer.java
@@ -18,9 +18,15 @@ public interface SkinRenderer<T extends Option<?>> {
         return option.isMouseOver(mouseX, mouseY);
     }
 
-    default void keyPressed(T option, int key) {}
+    default void keyPressed(T option, int key, int scanCode, int modifiers) {
+    }
 
-    default void keyReleased(T option, int key) {}
-    default void mouseScrolled(T option, double mouseX, double mouseY, double horizontalAmount, double verticalAmount){}
-    default void init(T option){}
+    default void keyReleased(T option, int key, int scanCode, int modifiers) {
+    }
+
+    default void mouseScrolled(T option, double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+    }
+
+    default void init(T option) {
+    }
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/widget/Widget.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widget/Widget.java
@@ -105,13 +105,13 @@ public abstract class Widget {
     private void updatePercentages() {
         int screenWidth = mc.getWindow().getScaledWidth();
         int screenHeight = mc.getWindow().getScaledHeight();
-        this.xPercent = (float) (this.x + this.getWidth() / 2) / screenWidth;
-        this.yPercent = (float) (this.y + this.getHeight() / 2) / screenHeight;
+        this.xPercent = (float) (this.x) / screenWidth;
+        this.yPercent = (float) (this.y) / screenHeight;
     }
 
     void updatePositionFromPercentages(int screenWidth, int screenHeight) {
-        this.x = (int) (this.xPercent * screenWidth - this.getWidth() / 2);
-        this.y = (int) (this.yPercent * screenHeight - this.getHeight() / 2);
+        this.x = (int) (this.xPercent * screenWidth);
+        this.y = (int) (this.yPercent * screenHeight);
 
         this.x = (int) MathHelper.clamp(x, 0, mc.getWindow().getScaledWidth() - getWidth());
         this.y = (int) MathHelper.clamp(y, 0, mc.getWindow().getScaledHeight() - getHeight());

--- a/src/main/java/com/tanishisherewith/dynamichud/widget/WidgetManager.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widget/WidgetManager.java
@@ -1,6 +1,7 @@
 package com.tanishisherewith.dynamichud.widget;
 
 import com.tanishisherewith.dynamichud.DynamicHUD;
+import com.tanishisherewith.dynamichud.mixins.ScreenMixin;
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtIo;
@@ -89,7 +90,7 @@ public class WidgetManager {
      * Larger the GUI scale, more accurate is the position on any resolution.
      * </p>
      * <p>
-     * Called in {@link com.tanishisherewith.dynamichud.mixins.ScreenMixin}
+     * Called in {@link ScreenMixin}
      * </p>
      * </p>
      *
@@ -101,6 +102,10 @@ public class WidgetManager {
     public static void onScreenResized(int newWidth, int newHeight, int previousWidth, int previousHeight) {
         for (Widget widget : widgets) {
             // To ensure that infinite coordinates is not returned for the first time its resized.
+
+            widget.updatePosition(newWidth, newHeight);
+
+            /*
             if (widget.xPercent <= 0.0f) {
                 widget.xPercent = (float) widget.getX() / previousWidth;
             }
@@ -112,6 +117,8 @@ public class WidgetManager {
 
             widget.xPercent = (widget.getX() + widget.getWidth() / 2) / newWidth;
             widget.yPercent = (widget.getY() + widget.getHeight() / 2) / newHeight;
+
+             */
         }
     }
 
@@ -198,6 +205,9 @@ public class WidgetManager {
         }
     }
 
+    public static boolean doesWidgetFileExist(File file){
+        return file.exists() || new File(file.getAbsolutePath() + ".backup").exists();
+    }
 
     /**
      * Returns the list of managed widgets.

--- a/src/main/java/com/tanishisherewith/dynamichud/widget/WidgetManager.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widget/WidgetManager.java
@@ -6,7 +6,6 @@ import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.NbtList;
-import net.minecraft.util.math.MathHelper;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -182,7 +181,7 @@ public class WidgetManager {
         widgets.clear();
 
         if (file.exists() || (file = new File(file.getAbsolutePath() + ".backup")).exists()) {
-            if(!file.exists()){
+            if (!file.exists()) {
                 printWarn("Main file " + file.getAbsolutePath() + " was not found... Loading from a found backup file");
             }
 
@@ -205,7 +204,7 @@ public class WidgetManager {
         }
     }
 
-    public static boolean doesWidgetFileExist(File file){
+    public static boolean doesWidgetFileExist(File file) {
         return file.exists() || new File(file.getAbsolutePath() + ".backup").exists();
     }
 

--- a/src/main/java/com/tanishisherewith/dynamichud/widget/WidgetRenderer.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widget/WidgetRenderer.java
@@ -2,6 +2,7 @@ package com.tanishisherewith.dynamichud.widget;
 
 import com.tanishisherewith.dynamichud.DynamicHUD;
 import com.tanishisherewith.dynamichud.screens.AbstractMoveableScreen;
+import com.tanishisherewith.dynamichud.utils.contextmenu.contextmenuscreen.ContextMenuScreen;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.gui.screen.Screen;
@@ -27,6 +28,7 @@ public class WidgetRenderer {
     public WidgetRenderer(List<Widget> widgets) {
         this.widgets = widgets;
         addScreen(GameMenuScreen.class);
+        addScreen(ContextMenuScreen.class);
     }
 
     public void addWidget(Widget widget) {
@@ -64,7 +66,7 @@ public class WidgetRenderer {
             return;
         }
         //Render in any other screen
-        if (currentScreen != null && allowedScreens.contains(DynamicHUD.MC.currentScreen.getClass()) && !this.isInEditor) {
+        if (currentScreen != null && allowedScreens.contains(DynamicHUD.MC.currentScreen.getClass())) {
             for (Widget widget : widgets) {
                 widget.isInEditor = false;
                 widget.render(context, 0, 0);

--- a/src/main/java/com/tanishisherewith/dynamichud/widgets/ItemWidget.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widgets/ItemWidget.java
@@ -12,27 +12,26 @@ import net.minecraft.nbt.NbtCompound;
  * This is just an example widget, not supposed to be used.
  */
 public class ItemWidget extends Widget {
-    public static WidgetData<?> DATA = new WidgetData<>("ItemWidget","Displays item texture", ItemWidget::new);
-    public ItemStack item;
-
-    public ItemWidget(ItemStack itemStack,String modId) {
+    public ItemStack item;    public static WidgetData<?> DATA = new WidgetData<>("ItemWidget", "Displays item texture", ItemWidget::new);
+    public ItemWidget(ItemStack itemStack, String modId) {
         super(DATA, modId);
         this.item = itemStack;
     }
+
     public ItemWidget() {
         this(ItemStack.EMPTY, "empty");
     }
 
     @Override
     public void renderWidget(DrawContext context, int mouseX, int mouseY) {
-        context.drawItem(item,x,y);
+        context.drawItem(item, x, y);
         widgetBox.setSizeAndPosition(getX(), getY(), 16, 16, this.shouldScale, GlobalConfig.get().getScale());
     }
 
     @Override
     public void writeToTag(NbtCompound tag) {
         super.writeToTag(tag);
-        tag.putInt("ItemID",Item.getRawId(item.getItem()));
+        tag.putInt("ItemID", Item.getRawId(item.getItem()));
     }
 
     @Override
@@ -45,8 +44,9 @@ public class ItemWidget extends Widget {
         this.item = item;
     }
 
-    public static class Builder extends WidgetBuilder<Builder,ItemWidget>{
-         ItemStack itemStack;
+    public static class Builder extends WidgetBuilder<Builder, ItemWidget> {
+        ItemStack itemStack;
+
         public Builder setItemStack(ItemStack itemStack) {
             this.itemStack = itemStack;
             return self();
@@ -59,7 +59,9 @@ public class ItemWidget extends Widget {
 
         @Override
         public ItemWidget build() {
-            return new ItemWidget(itemStack,modID);
+            return new ItemWidget(itemStack, modID);
         }
     }
+
+
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/widgets/TextWidget.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widgets/TextWidget.java
@@ -87,7 +87,7 @@ public class TextWidget extends Widget implements ContextMenuProvider {
         menu.addOption(new ColorOption("TextColor", menu, () -> this.textColor, value -> this.textColor = value));
         menu.addOption(new DoubleOption("RainbowSpeed", 1, 5.0f, 1, () -> (double) this.rainbowSpeed, value -> this.rainbowSpeed = value.intValue(),menu));
 
-        /*
+        /* TEST
         AtomicReference<String> option = new AtomicReference<>("Enum1");
         List<String> options = Arrays.asList("List1", "LONGER LIST 2", "List3");
         AtomicBoolean running = new AtomicBoolean(false);

--- a/src/main/java/com/tanishisherewith/dynamichud/widgets/TextWidget.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widgets/TextWidget.java
@@ -7,7 +7,9 @@ import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenu;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuManager;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProperties;
 import com.tanishisherewith.dynamichud.utils.contextmenu.ContextMenuProvider;
-import com.tanishisherewith.dynamichud.utils.contextmenu.options.*;
+import com.tanishisherewith.dynamichud.utils.contextmenu.options.BooleanOption;
+import com.tanishisherewith.dynamichud.utils.contextmenu.options.ColorOption;
+import com.tanishisherewith.dynamichud.utils.contextmenu.options.DoubleOption;
 import com.tanishisherewith.dynamichud.utils.contextmenu.skinsystem.MinecraftSkin;
 import com.tanishisherewith.dynamichud.widget.Widget;
 import com.tanishisherewith.dynamichud.widget.WidgetData;
@@ -16,26 +18,22 @@ import net.minecraft.nbt.NbtCompound;
 import org.lwjgl.glfw.GLFW;
 
 import java.awt.*;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 public class TextWidget extends Widget implements ContextMenuProvider {
     public Color textColor;
     protected boolean shadow; // Whether to draw a shadow behind the text
-    public static WidgetData<TextWidget> DATA = new WidgetData<>("TextWidget", "Display Text on screen", TextWidget::new);
     protected boolean rainbow; // Whether to apply a rainbow effect to the text
+    public static WidgetData<TextWidget> DATA = new WidgetData<>("TextWidget", "Display Text on screen", TextWidget::new);
     protected int rainbowSpeed = 2; //Speed of the rainbow effect
     Supplier<String> textSupplier;
     String dynamicRegistryKey;
     DynamicValueRegistry dynamicValueRegistry = null;
     private ContextMenu menu;
-
     public TextWidget() {
         this(null, null, false, false, Color.WHITE, "unknown");
     }
+
     /**
      * Searches for the supplier within the {@link DynamicValueRegistry#globalRegistry} using the given registryKey
      *
@@ -85,7 +83,7 @@ public class TextWidget extends Widget implements ContextMenuProvider {
         menu.addOption(new BooleanOption("Shadow", () -> this.shadow, value -> this.shadow = value, BooleanOption.BooleanType.ON_OFF));
         menu.addOption(new BooleanOption("Rainbow", () -> this.rainbow, value -> this.rainbow = value, BooleanOption.BooleanType.ON_OFF));
         menu.addOption(new ColorOption("TextColor", menu, () -> this.textColor, value -> this.textColor = value));
-        menu.addOption(new DoubleOption("RainbowSpeed", 1, 5.0f, 1, () -> (double) this.rainbowSpeed, value -> this.rainbowSpeed = value.intValue(),menu));
+        menu.addOption(new DoubleOption("RainbowSpeed", 1, 5.0f, 1, () -> (double) this.rainbowSpeed, value -> this.rainbowSpeed = value.intValue(), menu));
 
         /* TEST
         AtomicReference<String> option = new AtomicReference<>("Enum1");
@@ -111,7 +109,7 @@ public class TextWidget extends Widget implements ContextMenuProvider {
             drawContext.drawText(mc.textRenderer, text, getX() + 2, getY() + 2, color, shadow);
             widgetBox.setSizeAndPosition(getX(), getY(), mc.textRenderer.getWidth(text) + 3, mc.textRenderer.fontHeight + 2, this.shouldScale, GlobalConfig.get().getScale());
         }
-        menu.set(getX(),getY(),(int) Math.ceil(getHeight()));
+        menu.set(getX(), getY(), (int) Math.ceil(getHeight()));
     }
 
     @Override
@@ -173,7 +171,7 @@ public class TextWidget extends Widget implements ContextMenuProvider {
             dynamicValueRegistry = dvr;
             return;
         }
-         createMenu();
+        createMenu();
     }
 
     @Override
@@ -232,4 +230,6 @@ public class TextWidget extends Widget implements ContextMenuProvider {
             return widget;
         }
     }
+
+
 }

--- a/src/main/java/com/tanishisherewith/dynamichud/widgets/TextWidget.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widgets/TextWidget.java
@@ -77,7 +77,7 @@ public class TextWidget extends Widget implements ContextMenuProvider {
 
     public void createMenu() {
         ContextMenuProperties properties = ContextMenuProperties.builder()
-                .skin(new MinecraftSkin(MinecraftSkin.PanelColor.CREAMY))
+                .skin(new MinecraftSkin(MinecraftSkin.PanelColor.DARK_PANEL))
                 .build();
 
         menu = new ContextMenu(getX(), getY(), properties);

--- a/src/main/java/com/tanishisherewith/dynamichud/widgets/TextWidget.java
+++ b/src/main/java/com/tanishisherewith/dynamichud/widgets/TextWidget.java
@@ -232,8 +232,4 @@ public class TextWidget extends Widget implements ContextMenuProvider {
             return widget;
         }
     }
-
-
-
-
 }

--- a/src/main/resources/dynamichud.mixins.json
+++ b/src/main/resources/dynamichud.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.tanishisherewith.dynamichud.mixins",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "ScreenMixin"
   ],

--- a/src/main/resources/dynamichud.mixins.json
+++ b/src/main/resources/dynamichud.mixins.json
@@ -4,11 +4,10 @@
   "package": "com.tanishisherewith.dynamichud.mixins",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "ScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1
   },
-  "client": [
-    "ScreenMixin"
-  ]
+  "client": []
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     "repo": "https://github.com/V-Fast/DynamicHUD",
     "issues": "https://github.com/V-Fast/DynamicHUD/issues"
   },
-  "license": "All-Rights-Reserved",
+  "license": "MIT",
   "environment": "client",
   "entrypoints": {
     "client": [
@@ -31,11 +31,15 @@
   "depends": {
     "fabricloader": ">=${loader_version}",
     "fabric": "*",
+    "java": ">=21",
     "minecraft": "~${minecraft_version}"
   },
   "custom": {
     "modmenu": {
       "badges": ["library"]
     }
+  },
+  "suggests": {
+    "yet_another_config_lib_v3": "3.5.0+1.21-fabric"
   }
 }


### PR DESCRIPTION
1.  Providing Skin System for ContextMenu, providing global ContextMenuProvider and SkinRenderers. Including 2 default skins `Classic` and `Minecraft`.
2. ContextMenuScreen factory used for the same above changes.
3.  Various code improvements and test features.
4.  New widget anchoring system and actually loading from a backup file if found.
5.  More changes and a full reformat.
6.  Supports `1.21.1`
7.  The DynamicHudTest.java class is now automatically added for integration if the argument `--dynamicHudTest true` is passed while running Minecraft in program arguments.

TODO:

- [ ] Widget Tray :- The idea is that a user can discard/remove widgets from the screen temporarily and place them in a "tray" to be used later. So, the tray acts as a store conveyer to remove access unneeded widgets for the user.
- [ ] New Modern Skin Renderer.
- [ ] Add DynamicHUD YACL config screen to the game's options screen and remove Mod-Menu Integration (optional).
- [ ] More customization to widgets themselves for the user (like the background color when in the editor).
- [ ] Fix a few more issues regarding screen resize and widgets.
- [ ] Add more versatile HUD rendering.
- [ ] Add more usefull and fast Renderer2D functions.
- [ ] More stuff to add in this TODO